### PR TITLE
Format/Lint plugin always targets all target

### DIFF
--- a/Plugins/FormatPlugin/plugin.swift
+++ b/Plugins/FormatPlugin/plugin.swift
@@ -20,7 +20,7 @@ struct FormatPlugin {
     process.waitUntilExit()
     
     if process.terminationReason == .exit && process.terminationStatus == 0 {
-      print("Formatted the source code.")
+      Diagnostics.remark("Formatted the source code.")
     }
     else {
       let problem = "\(process.terminationReason):\(process.terminationStatus)"

--- a/Plugins/FormatPlugin/plugin.swift
+++ b/Plugins/FormatPlugin/plugin.swift
@@ -35,15 +35,13 @@ extension FormatPlugin: CommandPlugin {
     arguments: [String]
   ) async throws {
     let swiftFormatTool = try context.tool(named: "swift-format")
-    
+
     var argExtractor = ArgumentExtractor(arguments)
-    let targetNames = argExtractor.extractOption(named: "target")
-    let targetsToFormat = targetNames.isEmpty ? context.package.targets : try context.package.targets(named: targetNames)
-    
+
     let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
-    
-    let sourceCodeTargets = targetsToFormat.compactMap{ $0 as? SourceModuleTarget }
-    
+
+    let sourceCodeTargets = context.package.targets.compactMap{ $0 as? SourceModuleTarget }
+
     try format(
       tool: swiftFormatTool,
       targetDirectories: sourceCodeTargets.map(\.directory.string),

--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -35,16 +35,13 @@ extension LintPlugin: CommandPlugin {
     arguments: [String]
   ) async throws {
     let swiftFormatTool = try context.tool(named: "swift-format")
-    
+
     // Extract the arguments that specify what targets to format.
     var argExtractor = ArgumentExtractor(arguments)
-    let targetNames = argExtractor.extractOption(named: "target")
-    
-    let targetsToFormat = targetNames.isEmpty ? context.package.targets : try context.package.targets(named: targetNames)
     let configurationFilePath = argExtractor.extractOption(named: "swift-format-configuration").first
-    
-    let sourceCodeTargets = targetsToFormat.compactMap { $0 as? SourceModuleTarget }
-    
+
+    let sourceCodeTargets = context.package.targets.compactMap { $0 as? SourceModuleTarget }
+
     try lint(
       tool: swiftFormatTool,
       targetDirectories: sourceCodeTargets.map(\.directory.string),

--- a/Plugins/LintPlugin/plugin.swift
+++ b/Plugins/LintPlugin/plugin.swift
@@ -20,7 +20,7 @@ struct LintPlugin {
     process.waitUntilExit()
     
     if process.terminationReason == .exit && process.terminationStatus == 0 {
-      print("Linted the source code.")
+      Diagnostics.remark("Linted the source code.")
     }
     else {
       let problem = "\(process.terminationReason):\(process.terminationStatus)"


### PR DESCRIPTION
CommandPlugin can only select target listed in `Package.products`

But developer wants to format/lint all target  not listed in `Package.products`

I deleted the code extracting target from arguments

```swift
let package = Package(
  name: "swift-format",
  products: [
    .library(name: "SwiftFormat", targets: ["SwiftFormat"]),
  ]
}
```