### PR TITLE
feat: add pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: swift-format
+  name: swift-format
+  entry: swift-format format --in-place --recursive --parallel
+  language: swift
+  types: [swift]
+  require_serial: true


### PR DESCRIPTION
I took a shot at adding a pre-commit hooks files, according to [this guide](https://pre-commit.com/#new-hooks).

Fixes #676.

---

Once this is merged, it can be used in your other swift packages, by adding the following to the `.pre-commit-config.yaml` under the `repos` section, according to [the guide](https://pre-commit.com/#plugins).

```yaml
  - repo: https://github.com/apple/swift-format
    rev: <commit hash / tag>
    hooks:
      - id: swift-format
```