### PR TITLE
chore: fix SwiftPM warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,9 @@ let package = Package(
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
+      ],
+      exclude: [
+        "CMakeLists.txt"
       ]
     ),
     .target(
@@ -104,6 +107,9 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
+      ],
+      exclude: [
+        "CMakeLists.txt"
       ],
       linkerSettings: swiftformatLinkSettings
     ),


### PR DESCRIPTION
This pull request fixes the following warnings from SwiftPM.

```console
$ swift build
...
warning: 'swift-format': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /home/kebo/swift-format/Sources/swift-format/CMakeLists.txt
warning: 'swift-format': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /home/kebo/swift-format/Sources/SwiftFormat/CMakeLists.txt
...
```

Those files have been added in #677.

I confirmed that this PR fixed warnings in Swift 5.10, 6.0, and the main snapshot.