### PR TITLE
Fix a build issue in swift-format

### DIFF
--- a/Sources/SwiftFormat/API/Selection.swift
+++ b/Sources/SwiftFormat/API/Selection.swift
@@ -49,6 +49,14 @@ public enum Selection {
   }
 }
 
+extension Range<AbsolutePosition> {
+  // Returns `true` if the intersection between this range and `other` is non-empty or if the two ranges are directly
+  /// adjacent to each other.
+  public func overlapsOrTouches(_ other: Range<AbsolutePosition>) -> Bool {
+    return self.upperBound >= other.lowerBound && self.lowerBound <= other.upperBound
+  }
+}
+
 
 public extension Syntax {
   /// - Returns: `true` if the node is _completely_ inside any range in the selection


### PR DESCRIPTION
We didn’t catch this in cross-PR testing in https://github.com/swiftlang/swift-syntax/pull/2201 because I referenced https://github.com/swiftlang/swift-format/pull/760 using the *swiftlang* org but would have ended to use the *apple* org for cross-PR testing to pick #760 up. 