### PR TITLE
Add a break after `do` when it has typed throws

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -707,6 +707,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: DoStmtSyntax) -> SyntaxVisitorContinueKind {
+    if node.throwsClause != nil {
+      after(node.doKeyword, tokens: .break(.same, size: 1))
+    }
     arrangeBracesAndContents(of: node.body, contentsKeyPath: \.statements)
     return .visitChildren
   }

--- a/Tests/SwiftFormatTests/PrettyPrint/DoStmtTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/DoStmtTests.swift
@@ -57,5 +57,30 @@ final class DoStmtTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  func testDoTypedThrowsStmt() {
+    let input =
+      """
+      do throws(FooError) {
+        foo()
+      }
+      """
+
+    assertPrettyPrintEqual(input: input, expected:
+      """
+      do
+      throws(FooError) {
+        foo()
+      }
+
+      """, linelength: 18)
+    assertPrettyPrintEqual(input: input, expected:
+      """
+      do throws(FooError) {
+        foo()
+      }
+
+      """, linelength: 25)
+  }
 }
 


### PR DESCRIPTION
Pretty-printing of `do` statements with typed throws was skipping the space between the `do` and `throws`. Make sure to add it in.

Fixes #768.