### PR TITLE
[6.0] Improve formatting of macro decls with attributes

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1327,6 +1327,12 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
+    arrangeAttributeList(node.attributes)
+
+    before(
+      node.trailingClosure?.leftBrace,
+      tokens: .break(.same, newlines: .elective(ignoresDiscretionary: true)))
+
     arrangeFunctionCallArgumentList(
       node.arguments,
       leftDelimiter: node.leftParen,

--- a/Tests/SwiftFormatTests/PrettyPrint/MacroCallTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/MacroCallTests.swift
@@ -114,4 +114,16 @@ final class MacroCallTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  func testMacroDeclWithAttributesAndArguments() {
+    let input = """
+      @nonsenseAttribute
+      @available(iOS 17.0, *)
+      #Preview("Name") {
+        EmptyView()
+      }
+      
+      """
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 45)
+  }
 }


### PR DESCRIPTION
- **Explanation**: Whitespace and newlines were being lost in the token stream when prefixing a macro with an attribute. Call the common attribute handling code, and add a break before the left brace of the decl
- **Scope**: Formatting of macro expansion decls
- **Risk**: Very narrow change
- **Testing**: Added test case
- **Issue**: rdar://126948308, https://github.com/swiftlang/swift-format/issues/689
- **Reviewer**:   @ahoppen 