### PR TITLE
[6.0] Fix missing break in nested IfConfig decls

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1453,6 +1453,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   }
 
   override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    // there has to be a break after an #endif
+    after(node.poundEndif, tokens: .break(.same, size: 0))
     return .visitChildren
   }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
@@ -531,4 +531,30 @@ final class IfConfigTests: PrettyPrintTestCase {
       """
     assertPrettyPrintEqual(input: input, expected: input, linelength: 45)
   }
+
+  func testNestedPoundIfInSwitchStatement() {
+    let input =
+      """
+      switch self {
+      #if os(iOS) || os(tvOS) || os(watchOS)
+      case .a:
+        return 40
+      #if os(iOS) || os(tvOS)
+      case .e:
+        return 30
+      #endif
+      #if os(iOS)
+      case .g:
+        return 2
+      #endif
+      #endif
+      default:
+        return nil
+      }
+      
+      """
+    var configuration = Configuration.forTesting
+    configuration.indentConditionalCompilationBlocks = false
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 45, configuration: configuration)
+  }
 }


### PR DESCRIPTION
- **Explanation**: Forces `#endif` to always be followed by a newline, fixing incorrect formatting that could put `#endif` and a following `#if` on the same line
- **Scope**: Formatting of If config declarations
- **Risk**: Very narrow fix
- **Testing**: Added test case
- **Issue**: rdar://132365692, https://github.com/swiftlang/swift-format/issues/779
- **Reviewer**:   @ahoppen 