### PR TITLE
Add option to add a newline between 2 adjacent attributes

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -58,7 +58,7 @@ top-level keys and values:
     (the default), requirements will be laid out horizontally first, with line breaks 
     only being fired when the line length would be exceeded.
 
-*   `lineBreakBetweenDeclartionAttributes` _(boolean)_:  Determines the 
+*   `lineBreakBetweenDeclarationAttributes` _(boolean)_:  Determines the 
     line-breaking behavior for adjacent attributes on declarations.
     If true, a line break will be added between each attribute, forcing the
     attribute list to be laid out vertically. If false (the default),

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -58,6 +58,13 @@ top-level keys and values:
     (the default), requirements will be laid out horizontally first, with line breaks 
     only being fired when the line length would be exceeded.
 
+*   `lineBreakBetweenDeclartionAttributes` _(boolean)_:  Determines the 
+    line-breaking behavior for adjacent attributes on declarations.
+    If true, a line break will be added between each attribute, forcing the
+    attribute list to be laid out vertically. If false (the default),
+    attributes will be laid out horizontally first, with line breaks only
+    being fired when the line length would be exceeded.
+
 *   `prioritizeKeepingFunctionOutputTogether` _(boolean)_: Determines if 
     function-like declaration outputs should be prioritized to be together with the
     function signature right (closing) parenthesis. If false (the default), function 

--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -30,6 +30,7 @@ extension Configuration {
     self.lineBreakBeforeControlFlowKeywords = false
     self.lineBreakBeforeEachArgument = false
     self.lineBreakBeforeEachGenericRequirement = false
+    self.lineBreakBetweenDeclarationAttributes = false
     self.prioritizeKeepingFunctionOutputTogether = false
     self.indentConditionalCompilationBlocks = true
     self.lineBreakAroundMultilineExpressionChainComponents = false

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -34,6 +34,7 @@ public struct Configuration: Codable, Equatable {
     case lineBreakBeforeControlFlowKeywords
     case lineBreakBeforeEachArgument
     case lineBreakBeforeEachGenericRequirement
+    case lineBreakBetweenDeclarationAttributes
     case prioritizeKeepingFunctionOutputTogether
     case indentConditionalCompilationBlocks
     case lineBreakAroundMultilineExpressionChainComponents
@@ -110,6 +111,9 @@ public struct Configuration: Codable, Equatable {
   /// list to be laid out vertically. If false (the default), requirements will be laid out
   /// horizontally first, with line breaks only being fired when the line length would be exceeded.
   public var lineBreakBeforeEachGenericRequirement: Bool
+
+  /// If true, a line break will be added between adjacent attributes.
+  public var lineBreakBetweenDeclarationAttributes: Bool
 
   /// Determines if function-like declaration outputs should be prioritized to be together with the
   /// function signature right (closing) parenthesis.
@@ -243,6 +247,9 @@ public struct Configuration: Codable, Equatable {
     self.lineBreakBeforeEachGenericRequirement =
       try container.decodeIfPresent(Bool.self, forKey: .lineBreakBeforeEachGenericRequirement)
       ?? defaults.lineBreakBeforeEachGenericRequirement
+    self.lineBreakBetweenDeclarationAttributes =
+      try container.decodeIfPresent(Bool.self, forKey: .lineBreakBetweenDeclarationAttributes)
+      ?? defaults.lineBreakBetweenDeclarationAttributes
     self.prioritizeKeepingFunctionOutputTogether =
       try container.decodeIfPresent(Bool.self, forKey: .prioritizeKeepingFunctionOutputTogether)
       ?? defaults.prioritizeKeepingFunctionOutputTogether
@@ -296,6 +303,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(lineBreakBeforeEachGenericRequirement, forKey: .lineBreakBeforeEachGenericRequirement)
     try container.encode(prioritizeKeepingFunctionOutputTogether, forKey: .prioritizeKeepingFunctionOutputTogether)
     try container.encode(indentConditionalCompilationBlocks, forKey: .indentConditionalCompilationBlocks)
+    try container.encode(lineBreakBetweenDeclarationAttributes, forKey: .lineBreakBetweenDeclarationAttributes)
     try container.encode(
       lineBreakAroundMultilineExpressionChainComponents,
       forKey: .lineBreakAroundMultilineExpressionChainComponents)

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -468,4 +468,112 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
   }
+
+  func testLineBreakBetweenDeclarationAttributes() {
+    let input =
+      """
+      @_spi(Private) @_spi(InviteOnly) import SwiftFormat
+
+      @available(iOS 14.0, *) @available(macOS 11.0, *)
+      public protocol P {
+        @available(iOS 16.0, *) @available(macOS 14.0, *)
+        #if DEBUG
+          @available(tvOS 17.0, *) @available(watchOS 10.0, *)
+        #endif
+        @available(visionOS 1.0, *)
+        associatedtype ID
+      }
+
+      @available(iOS 14.0, *) @available(macOS 11.0, *)
+      public enum Dimension {
+        case x
+        case y
+        @available(iOS 17.0, *) @available(visionOS 1.0, *)
+        case z
+      }
+
+      @available(iOS 16.0, *) @available(macOS 14.0, *)
+      @available(tvOS 16.0, *) @frozen
+      struct X {
+        @available(iOS 17.0, *) @available(macOS 15.0, *)
+        typealias ID = UUID
+
+        @available(iOS 17.0, *) @available(macOS 15.0, *)
+        var callMe: @MainActor @Sendable () -> Void
+
+        @available(iOS 17.0, *) @available(macOS 15.0, *)
+        @MainActor @discardableResult
+        func f(@_inheritActorContext body: @MainActor @Sendable () -> Void) {}
+
+        @available(iOS 17.0, *) @available(macOS 15.0, *) @MainActor
+        var foo: Foo {
+          get { Foo() }
+          @available(iOS, obsoleted: 17.0) @available(macOS 15.0, obsoleted: 15.0)
+          set { fatalError() }
+        }
+      }
+      """
+
+    let expected =
+      """
+      @_spi(Private) @_spi(InviteOnly) import SwiftFormat
+
+      @available(iOS 14.0, *)
+      @available(macOS 11.0, *)
+      public protocol P {
+        @available(iOS 16.0, *)
+        @available(macOS 14.0, *)
+        #if DEBUG
+          @available(tvOS 17.0, *)
+          @available(watchOS 10.0, *)
+        #endif
+        @available(visionOS 1.0, *)
+        associatedtype ID
+      }
+
+      @available(iOS 14.0, *)
+      @available(macOS 11.0, *)
+      public enum Dimension {
+        case x
+        case y
+        @available(iOS 17.0, *)
+        @available(visionOS 1.0, *)
+        case z
+      }
+
+      @available(iOS 16.0, *)
+      @available(macOS 14.0, *)
+      @available(tvOS 16.0, *)
+      @frozen
+      struct X {
+        @available(iOS 17.0, *)
+        @available(macOS 15.0, *)
+        typealias ID = UUID
+
+        @available(iOS 17.0, *)
+        @available(macOS 15.0, *)
+        var callMe: @MainActor @Sendable () -> Void
+
+        @available(iOS 17.0, *)
+        @available(macOS 15.0, *)
+        @MainActor
+        @discardableResult
+        func f(@_inheritActorContext body: @MainActor @Sendable () -> Void) {}
+
+        @available(iOS 17.0, *)
+        @available(macOS 15.0, *)
+        @MainActor
+        var foo: Foo {
+          get { Foo() }
+          @available(iOS, obsoleted: 17.0)
+          @available(macOS 15.0, obsoleted: 15.0)
+          set { fatalError() }
+        }
+      }
+
+      """
+      var configuration = Configuration.forTesting
+      configuration.lineBreakBetweenDeclarationAttributes = true
+      assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: configuration)
+  }
 }


### PR DESCRIPTION
Add an option that inserts hard line breaks between adjacent attributes.

Closes #773