### PR TITLE
Modify assertLint test helper to run via pipeline only.

### DIFF
--- a/Tests/SwiftFormatTests/Rules/DontRepeatTypeInStaticPropertiesTests.swift
+++ b/Tests/SwiftFormatTests/Rules/DontRepeatTypeInStaticPropertiesTests.swift
@@ -75,4 +75,22 @@ final class DontRepeatTypeInStaticPropertiesTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+
+  func testIgnoreSingleDecl() {
+    assertLint(
+      DontRepeatTypeInStaticProperties.self,
+        """
+        struct Foo {
+          // swift-format-ignore: DontRepeatTypeInStaticProperties
+          static let defaultFoo: Int
+          static let 1️⃣alternateFoo: Int
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "remove the suffix 'Foo' from the name of the variable 'alternateFoo'"),
+      ]
+    )
+  }
+
 }

--- a/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
@@ -42,16 +42,6 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
       configuration: configuration,
       selection: .infinite,
       findingConsumer: { emittedFindings.append($0) })
-    let linter = type.init(context: context)
-    linter.walk(sourceFileSyntax)
-
-    assertFindings(
-      expected: findings,
-      markerLocations: markedText.markers,
-      emittedFindings: emittedFindings,
-      context: context,
-      file: file,
-      line: line)
 
     var emittedPipelineFindings = [Finding]()
     // Disable default rules, so only select rule runs in pipeline
@@ -66,7 +56,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
       operatorTable: OperatorTable.standardOperators,
       assumingFileURL: URL(string: file.description)!)
 
-    // Check that pipeline produces the same findings as the isolated linter rule
+    // Check that pipeline produces the expected findings
     assertFindings(
       expected: findings,
       markerLocations: markedText.markers,


### PR DESCRIPTION
Standalone lint visitors don't check for swift-format-ignore markers, so any test cases that use those markers will return different results between standalone vs full pipeline.