### PR TITLE
Remove closure capture equal sign spacing.

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1271,8 +1271,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: ClosureCaptureSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
     after(node.specifier?.lastToken(viewMode: .sourceAccurate), tokens: .break)
-    before(node.equal, tokens: .break)
-    after(node.equal, tokens: .break)
     if let trailingComma = node.trailingComma {
       before(trailingComma, tokens: .close)
       after(trailingComma, tokens: .break(.same))


### PR DESCRIPTION
This change comes due to the new `ClosureCaptureSyntax` structure and deprecation of `ClosureCaptureSyntax.equal` property in [this PR](https://github.com/swiftlang/swift-syntax/pull/2763#issuecomment-2266129896).