### PR TITLE
Wrap multiline string literals to line length.

### DIFF
--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -40,5 +40,6 @@ extension Configuration {
     self.spacesAroundRangeFormationOperators = false
     self.noAssignmentInExpressions = NoAssignmentInExpressionsConfiguration()
     self.multiElementCollectionTrailingCommas = true
+    self.reflowMultilineStringLiterals = .never
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -45,6 +45,7 @@ public struct Configuration: Codable, Equatable {
     case spacesAroundRangeFormationOperators
     case noAssignmentInExpressions
     case multiElementCollectionTrailingCommas
+    case reflowMultilineStringLiterals
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -194,6 +195,71 @@ public struct Configuration: Codable, Equatable {
   /// ```
   public var multiElementCollectionTrailingCommas: Bool
 
+  /// Determines how multiline string literals should reflow when formatted.
+  public enum MultilineStringReflowBehavior: Codable {
+    /// Never reflow multiline string literals.
+    case never
+    /// Reflow lines in string literal that exceed the maximum line length. For example with a line length of 10:
+    /// ```swift
+    /// """
+    /// an escape\
+    ///  line break
+    /// a hard line break
+    /// """
+    /// ```
+    /// will be formatted as:
+    /// ```swift
+    /// """
+    /// an esacpe\
+    ///  line break
+    /// a hard \
+    /// line break
+    /// """
+    /// ```
+    /// The existing `\` is left in place, but the line over line length is broken.
+    case onlyLinesOverLength
+    /// Always reflow multiline string literals, this will ignore existing escaped newlines in the literal and reflow each line. Hard linebreaks are still respected.
+    /// For example, with a line length of 10:
+    /// ```swift
+    /// """
+    /// one \
+    /// word \
+    /// a line.
+    /// this is too long.
+    /// """
+    /// ```
+    /// will be formatted as:
+    /// ```swift
+    /// """
+    /// one word \
+    /// a line.
+    /// this is \
+    /// too long.
+    /// """
+    /// ```
+    case always
+
+    var isNever: Bool {
+      switch self {
+      case .never:
+        return true
+      default:
+        return false
+      }
+    }
+
+    var isAlways: Bool {
+      switch self {
+      case .always:
+        return true
+      default:
+        return false
+      }
+    }
+  }
+
+  public var reflowMultilineStringLiterals: MultilineStringReflowBehavior
+
   /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -287,6 +353,10 @@ public struct Configuration: Codable, Equatable {
         Bool.self, forKey: .multiElementCollectionTrailingCommas)
     ?? defaults.multiElementCollectionTrailingCommas
 
+    self.reflowMultilineStringLiterals =
+      try container.decodeIfPresent(MultilineStringReflowBehavior.self, forKey: .reflowMultilineStringLiterals)
+      ?? defaults.reflowMultilineStringLiterals
+
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
     // default-initialized. To get an empty rules dictionary, one can explicitly
@@ -321,6 +391,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(indentSwitchCaseLabels, forKey: .indentSwitchCaseLabels)
     try container.encode(noAssignmentInExpressions, forKey: .noAssignmentInExpressions)
     try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
+    try container.encode(reflowMultilineStringLiterals, forKey: .reflowMultilineStringLiterals)
     try container.encode(rules, forKey: .rules)
   }
 

--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
@@ -81,6 +81,8 @@ struct PrettyPrintBuffer {
       numberToPrint = min(count, maximumBlankLines + 1) - consecutiveNewlineCount
     case .hard(let count):
       numberToPrint = count
+    case .escaped:
+      numberToPrint = 1
     }
 
     guard numberToPrint > 0 else { return }

--- a/Sources/SwiftFormat/PrettyPrint/Token.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Token.swift
@@ -147,6 +147,10 @@ enum NewlineBehavior {
   /// newlines and the configured maximum number of blank lines.
   case hard(count: Int)
 
+  /// Break onto a new line is allowed if neccessary. If a line break is emitted, it will be escaped with a '\', and this breaks whitespace will be printed prior to the
+  /// escaped line break. This is useful in multiline strings where we don't want newlines printed in syntax to appear in the literal.
+  case escaped
+
   /// An elective newline that respects discretionary newlines from the user-entered text.
   static let elective = NewlineBehavior.elective(ignoresDiscretionary: false)
 

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -15,7 +15,7 @@ import SwiftOperators
 import SwiftSyntax
 
 fileprivate extension AccessorBlockSyntax {
-  /// Assuming that the accessor only contains an implicit getter (i.e. no 
+  /// Assuming that the accessor only contains an implicit getter (i.e. no
   /// `get` or `set`), return the code block items in that getter.
   var getterCodeBlockItems: CodeBlockItemListSyntax {
     guard case .getter(let codeBlockItemList) = self.accessors else {
@@ -1437,9 +1437,9 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
     if node.parent?.is(FunctionTypeSyntax.self) ?? false {
-      // `FunctionTypeSyntax` used to not use `ReturnClauseSyntax` and had 
-      // slightly different formatting behavior than the normal 
-      // `ReturnClauseSyntax`. To maintain the previous formatting behavior, 
+      // `FunctionTypeSyntax` used to not use `ReturnClauseSyntax` and had
+      // slightly different formatting behavior than the normal
+      // `ReturnClauseSyntax`. To maintain the previous formatting behavior,
       // add a special case.
       before(node.arrow, tokens: .break)
       before(node.type.firstToken(viewMode: .sourceAccurate), tokens: .break)
@@ -1819,7 +1819,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
   override func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
     after(node.colon.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
     after(node.comma.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
-      return .visitChildren
+    return .visitChildren
   }
 
   override func visit(_ node: DocumentationAttributeArgumentSyntax) -> SyntaxVisitorContinueKind {
@@ -2446,6 +2446,13 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       if !node.segments.isEmpty {
         before(node.closingQuote, tokens: .break(breakKind, newlines: .hard(count: 1)))
       }
+      if shouldFormatterIgnore(node: Syntax(node)) {
+        appendFormatterIgnored(node: Syntax(node))
+        // Mirror the tokens we'd normally append on '"""'
+        appendTrailingTrivia(node.closingQuote)
+        appendAfterTokensAndTrailingComments(node.closingQuote)
+        return .skipChildren
+      }
     }
     return .visitChildren
   }
@@ -2460,17 +2467,69 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: StringSegmentSyntax) -> SyntaxVisitorContinueKind {
-    // Looks up the correct break kind based on prior context.
-    func breakKind() -> BreakKind {
-      if let stringLiteralSegments = node.parent?.as(StringLiteralSegmentListSyntax.self),
-        let stringLiteralExpr = stringLiteralSegments.parent?.as(StringLiteralExprSyntax.self)
-      {
-        return pendingMultilineStringBreakKinds[stringLiteralExpr, default: .same]
-      } else {
-        return .same
+  // Insert an `.escaped` break token after each series of whitespace in a substring
+  private func emitMultilineSegmentTextTokens(breakKind: BreakKind, segment: Substring) {
+    var currentWord = [Unicode.Scalar]()
+    var currentBreak = [Unicode.Scalar]()
+
+    func emitWord() {
+      if !currentWord.isEmpty {
+        var str = ""
+        str.unicodeScalars.append(contentsOf: currentWord)
+        appendToken(.syntax(str))
+        currentWord = []
       }
     }
+    func emitBreak() {
+      if !currentBreak.isEmpty {
+        // We append this as a syntax, instead of a `.space`, so that it is always included in the output.
+        var str = ""
+        str.unicodeScalars.append(contentsOf: currentBreak)
+        appendToken(.syntax(str))
+        appendToken(.break(breakKind, size: 0, newlines: .escaped))
+        currentBreak = []
+      }
+    }
+
+    for scalar in segment.unicodeScalars {
+      // We don't have to worry about newlines occurring in segments.
+      // Either a segment will end in a newline character or the newline will be in trivia.
+      if scalar.properties.isWhitespace {
+        emitWord()
+        currentBreak.append(scalar)
+      } else {
+        emitBreak()
+        currentWord.append(scalar)
+      }
+    }
+
+    // Only one of these will actually do anything based on whether our last char was whitespace or not.
+    emitWord()
+    emitBreak()
+  }
+
+  override func visit(_ node: StringSegmentSyntax) -> SyntaxVisitorContinueKind {
+    // Looks up the correct break kind based on prior context.
+    let stringLiteralParent =
+      node.parent?
+        .as(StringLiteralSegmentListSyntax.self)?
+        .parent?
+        .as(StringLiteralExprSyntax.self)
+    let breakKind = stringLiteralParent.map {
+      pendingMultilineStringBreakKinds[$0, default: .same]
+    } ?? .same
+
+    let isMultiLineString =
+      stringLiteralParent?.openingQuote.tokenKind == .multilineStringQuote
+      // We don't reflow raw strings, so treat them as if they weren't multiline
+      && stringLiteralParent?.openingPounds == nil
+
+    let emitSegmentTextTokens =
+      // If our configure reflow behavior is never, always use the single line emit segment text tokens.
+      isMultiLineString && !config.reflowMultilineStringLiterals.isNever
+        ? { (segment) in  self.emitMultilineSegmentTextTokens(breakKind: breakKind, segment: segment) }
+        // For single line strings we don't allow line breaks, so emit the string as a single `.syntax` token
+        : { (segment) in self.appendToken(.syntax(String(segment))) }
 
     let segmentText = node.content.text
     if segmentText.hasSuffix("\n") {
@@ -2478,20 +2537,22 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
       // append the rest of the string, followed by a break if it's not the last line before the
       // closing quotes. (The `StringLiteralExpr` above does the closing break.)
       let remainder = node.content.text.dropLast()
+
       if !remainder.isEmpty {
-        appendToken(.syntax(String(remainder)))
+        // Replace each space in the segment text by an elective break of size 1
+        emitSegmentTextTokens(remainder)
       }
-      appendToken(.break(breakKind(), newlines: .hard(count: 1)))
+      appendToken(.break(breakKind, newlines: .hard(count: 1)))
     } else {
-      appendToken(.syntax(segmentText))
+      emitSegmentTextTokens(segmentText[...])
     }
 
-    if node.trailingTrivia.containsBackslashes {
+    if node.trailingTrivia.containsBackslashes && !config.reflowMultilineStringLiterals.isAlways {
       // Segments with trailing backslashes won't end with a literal newline; the backslash is
       // considered trivia. To preserve the original text and wrapping, we need to manually render
       // the backslash and a break into the token stream.
       appendToken(.syntax("\\"))
-      appendToken(.break(breakKind(), newlines: .hard(count: 1)))
+      appendToken(.break(breakKind, newlines: .hard(count: 1)))
     }
     return .skipChildren
   }
@@ -3198,7 +3259,8 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
           // There must be a break with a soft newline after the comment, but it's impossible to
           // know which kind of break must be used. Adding this newline is deferred until the
           // comment is added to the token stream.
-      ])
+        ]
+      )
 
     case .blockComment(let text):
       return (
@@ -3487,12 +3549,18 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
     if let last = tokens.last {
       switch (last, token) {
+      case (.break(_, _, .escaped), _), (_, .break(_, _, .escaped)):
+        lastBreakIndex = tokens.endIndex
+        // Don't allow merging for .escaped breaks
+        canMergeNewlinesIntoLastBreak = false
+        tokens.append(token)
+        return
       case (.break(let breakKind, _, .soft(1, _)), .comment(let c2, _))
         where breakAllowsCommentMerge(breakKind) && (c2.kind == .docLine || c2.kind == .line):
         // we are search for the pattern of [line comment] - [soft break 1] - [line comment]
         // where the comment type is the same; these can be merged into a single comment
         if let nextToLast = tokens.dropLast().last,
-          case let .comment(c1, false) = nextToLast, 
+          case let .comment(c1, false) = nextToLast,
           c1.kind == c2.kind
         {
           var mergedComment = c1
@@ -4291,6 +4359,10 @@ extension NewlineBehavior {
       // `lhs` is either also elective or a required newline, which overwrites elective.
       return lhs
 
+    case (.escaped, _):
+      return rhs
+    case (_, .escaped):
+      return lhs
     case (.soft(let lhsCount, let lhsDiscretionary), .soft(let rhsCount, let rhsDiscretionary)):
       let mergedCount: Int
       if lhsDiscretionary && rhsDiscretionary {


### PR DESCRIPTION
Modify the pretty printer to insert escaped newlines "\\\n" when a line would exceed configured line length. This only affects multi-line strings and not single-line strings. Previously string segements in multiline literals were treated as one large `.syntax` token. They are now broken up into multiple tokens to allow opportunities to line break.

A string segement `"the quick fox"` will now be comprised of the tokens:
```swift
[.syntax("the"), .syntax(" "), .break(.escaped), .syntax("quick"), .syntax(" "), .break(.escaped), .syntax("fox")]
```
we now break up the segment based on whitespace. After each series of whitespace, we insert the new `.escaped` break.
A couple of odd things to note here:
-  A new NewlineBehavior: `.escaped`
- Tokens include both the whitespace and the line break
- We emit whitespace as a `.syntax` and not a `.space`

`.escaped` is very similar to an `.elective` line break. It will only break when it exceed the line length, otherwise it will be printed as `size` spaces. Unlike `.elective`, when it is printed it will print as an escaped newline "\\\n". On the implementation side we also have to calculate it's length differently than we do for `.elective`.

Because all whitespace in a string literal is significant (unlike whitespace in other swift syntax), it is emitted alongside the break. This is because, unlike other breaks, we always want to print the whitespace in a string literal. The choice to print the whitespace prior to the line break is cosmetic.

Whitespace is emitted as a `.syntax` to avoid special casing between `.break`s and `.space`s. The pretty printer will ignore spaces (or change them) around line breaks to make code look better. However this doesn't work for string literals where the whitespace is significant. Emitting `.syntax` token ensures all whitespace in the literal shows up. 

For example, the literal:
```swift
"""
Lorem ipsum odor amet, consectetuer adipiscing elit. Vehicula aptent per convallis fermentum mus. Rutrum ultrices nisl etiam et volutpat dictum pulvinar elementum felis.
"""
```
will be formatted as:
```swift
"""
Lorem ipsum odor amet, consectetuer adipiscing \
elit. Vehicula aptent per convallis fermentum mus. \
Rutrum ultrices nisl etiam et volutpat dictum \
pulvinar elementum felis.
"""
```


Wrapping will reflow escaped newlines already present in the string literal. For example, with a line length of 30:

```swift
"""
multi-line \
string.
"""
```

will be formatted as:

```swift
"""
multi-line string.
"""
```

However hard line breaks are always respected, since they appear in the string literal itself not just the syntax. So:

```swift
"""
multi-line
string
"""
```

will not be reformatted.


Breaks are only inserted after whitespace, so words longer than line length will not be wrapped (line length 30):

```swift
"""
long word: 01914cc5-a274-7df4-b88b-5e167f3f5662
"""
```
will be formatted as
```swift
"""
long word: \
01914cc5-a274-7df4-b88b-5e167f3f5662
"""
```
even though the second line exceeds 30 characters.

Fixes #724 