### PR TITLE
Fix extraction of trailing comments only when necessary during afterToken addition

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2929,8 +2929,16 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
         var shouldExtractTrailingComment = false
         if wasLineComment && !hasAppendedTrailingComment {
           switch afterToken {
-          case .break, .printerControl: shouldExtractTrailingComment = true
-          default: break
+          case let .break(kind, _, _):
+            if case let .close(mustBreak) = kind {
+              shouldExtractTrailingComment = mustBreak
+            } else {
+              shouldExtractTrailingComment = true
+            }
+          case .printerControl: 
+            shouldExtractTrailingComment = true
+          default: 
+            break
           }
         }
         if shouldExtractTrailingComment {

--- a/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommaTests.swift
@@ -143,6 +143,102 @@ final class CommaTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
   }
   
+  func testArrayWithCommentCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        1,
+        2 // some comment
+      ]
+
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        1,
+        2,  // some comment
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multiElementCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testArrayWithCommentCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        1,
+        2 // some comment
+      ]
+
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        1,
+        2  // some comment
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multiElementCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testArrayWithTernaryOperatorAndCommentCommasPresentEnabled() {
+    let input =
+      """
+      let MyCollection = [
+        1,
+        true ? 1 : 2 // some comment
+      ]
+
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        1,
+        true ? 1 : 2,  // some comment
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multiElementCollectionTrailingCommas = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+  
+  func testArrayWithTernaryOperatorAndCommentCommasPresentDisabled() {
+    let input =
+      """
+      let MyCollection = [
+        1,
+        true ? 1 : 2 // some comment
+      ]
+
+      """
+    
+    let expected =
+      """
+      let MyCollection = [
+        1,
+        true ? 1 : 2  // some comment
+      ]
+      
+      """
+    
+    var configuration = Configuration.forTesting
+    configuration.multiElementCollectionTrailingCommas = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 40, configuration: configuration)
+  }
+
   func testDictionaryCommasAbsentEnabled() {
     let input =
       """


### PR DESCRIPTION
Resolve #795 