### PR TITLE
Fix to arrange attributeList for attributes starting with ifConfig

### DIFF
--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -576,4 +576,27 @@ final class AttributeTests: PrettyPrintTestCase {
       configuration.lineBreakBetweenDeclarationAttributes = true
       assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: configuration)
   }
+
+  func testAttributesStartWithPoundIf() {
+    let input =
+      """
+      #if os(macOS)
+      @available(macOS, unavailable)
+      @_spi(Foo)
+      #endif
+      public let myVar = "Test"
+      
+      """
+    let expected =
+      """
+      #if os(macOS)
+        @available(macOS, unavailable)
+        @_spi(Foo)
+      #endif
+      public let myVar = "Test"
+      
+      """
+    
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
 }


### PR DESCRIPTION
Resolve #799 

It seems that when attributes start with `#if`, `attributes.dropLast` is empty, preventing the arrangement of attributeList inside IfConfigDeclSyntax. 
Fixed to allow arranging attribute list inside IfConfigDeclSyntax when AttributeListSyntax starts with `#if`.