### PR TITLE
Fix link to configuration in rule documentation file

### DIFF
--- a/Documentation/RuleDocumentation.md
+++ b/Documentation/RuleDocumentation.md
@@ -4,7 +4,7 @@
 
 Use the rules below in the `rules` block of your `.swift-format`
 configuration file, as described in
-[Configuration](Documentation/Configuration.md). All of these rules can be
+[Configuration](Configuration.md). All of these rules can be
 applied in the linter, but only some of them can format your source code
 automatically.
 


### PR DESCRIPTION
The link in the `RuleDocumentation.md` file to the configuration was broken because we need to provide a relative URL path