### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -2369,7 +2369,7 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
 
   override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
     before(node.firstToken(viewMode: .sourceAccurate), tokens: .open)
-    after(node.eachKeyword, tokens: .break)
+    after(node.specifier, tokens: .break)
     after(node.colon, tokens: .break)
     if let trailingComma = node.trailingComma {
       after(trailingComma, tokens: .close, .break(.same))

--- a/Sources/generate-swift-format/FileGenerator.swift
+++ b/Sources/generate-swift-format/FileGenerator.swift
@@ -19,6 +19,10 @@ protocol FileGenerator {
   func write(into handle: FileHandle) throws
 }
 
+private struct FailedToCreateFileError: Error {
+  let url: URL
+}
+
 extension FileGenerator {
   /// Generates a file at the given URL, overwriting it if it already exists.
   func generateFile(at url: URL) throws {
@@ -27,7 +31,9 @@ extension FileGenerator {
       try fm.removeItem(at: url)
     }
 
-    fm.createFile(atPath: url.path, contents: nil, attributes: nil)
+    if !fm.createFile(atPath: url.path, contents: nil, attributes: nil) {
+      throw FailedToCreateFileError(url: url)
+    }
     let handle = try FileHandle(forWritingTo: url)
     defer { handle.closeFile() }
 

--- a/Tests/swift-formatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/swift-formatTests/Utilities/FileIteratorTests.swift
@@ -70,7 +70,12 @@ extension FileIteratorTests {
     let fileURL = tmpURL(path)
     try FileManager.default.createDirectory(
       at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-    FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+    struct FailedToCreateFileError: Error {
+      let url: URL
+    }
+    if !FileManager.default.createFile(atPath: fileURL.path, contents: Data()) {
+      throw FailedToCreateFileError(url: fileURL)
+    }
   }
 
   /// Create a symlink between files or directories in the test's temporary space.


### PR DESCRIPTION
This makes swift-format build without warnings again.