### PR TITLE
Use human-readable names in pull_request action and consistently use 2 spaces for indentation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,10 +1,10 @@
-name: pull_request
+name: Pull request
 
 on:
-    pull_request:
-      types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-   tests:
-        name: tests
-        uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main


### PR DESCRIPTION
I think using `Pull request / Test` as the name looks nicer than `pull_request / tests`. I think the list of required actions needs to be updated for this PR.

New:
<img width="799" alt="Screenshot 2024-09-29 at 08 20 11" src="https://github.com/user-attachments/assets/4d24f5b3-230f-43b5-965e-08afc7a6367c">

Old:
<img width="798" alt="Screenshot 2024-09-29 at 08 19 55" src="https://github.com/user-attachments/assets/dced4071-e83c-4a27-b924-cc1d9bf908c1">

