### PR TITLE
Move tests in `swift-formatTests` to `SwiftFormatTests`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -131,11 +131,7 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ]
-    ),
-    .testTarget(
-      name: "swift-formatTests",
-      dependencies: ["swift-format"]
-    ),
+    )
   ]
 )
 

--- a/Sources/SwiftFormat/CMakeLists.txt
+++ b/Sources/SwiftFormat/CMakeLists.txt
@@ -96,7 +96,8 @@ add_library(SwiftFormat
   Rules/UseSynthesizedInitializer.swift
   Rules/UseTripleSlashForDocumentationComments.swift
   Rules/UseWhereClausesInForLoops.swift
-  Rules/ValidateDocumentationComments.swift)
+  Rules/ValidateDocumentationComments.swift
+  Utilities/FileIterator.swift)
 target_link_libraries(SwiftFormat PUBLIC
   SwiftMarkdown::Markdown
   SwiftSyntax::SwiftSyntax

--- a/Sources/SwiftFormat/Utilities/FileIterator.swift
+++ b/Sources/SwiftFormat/Utilities/FileIterator.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Iterator for looping over lists of files and directories. Directories are automatically
 /// traversed recursively, and we check for files with a ".swift" extension.
-@_spi(Testing)
+@_spi(Internal)
 public struct FileIterator: Sequence, IteratorProtocol {
 
   /// List of file and directory URLs to iterate over.

--- a/Sources/swift-format/CMakeLists.txt
+++ b/Sources/swift-format/CMakeLists.txt
@@ -23,7 +23,6 @@ add_executable(swift-format
   Utilities/Diagnostic.swift
   Utilities/DiagnosticsEngine.swift
   Utilities/FileHandleTextOutputStream.swift
-  Utilities/FileIterator.swift
   Utilities/FormatError.swift
   Utilities/StderrDiagnosticPrinter.swift
   Utilities/TTY.swift)

--- a/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@_spi(Testing) import swift_format
+@_spi(Internal) import SwiftFormat
 
 final class FileIteratorTests: XCTestCase {
   private var tmpdir: URL!


### PR DESCRIPTION
Windows doesn’t support test targets that depend on executables. Move `FileIterator` into `SwiftFormat` so we can test it as part of `SwiftFormatTests` and can remove `swift-formatTests`.