### PR TITLE
Allow the `Publish Release` action to create a tag and release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -85,6 +85,8 @@ jobs:
     name: Create Tag
     runs-on: ubuntu-latest
     needs: [check_triggering_actor, test_debug, test_release, define_tags]
+    permissions:
+      contents: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Without this, publishing a release fails: https://github.com/swiftlang/swift-format/actions/runs/11115499335/job/30884437932