### PR TITLE
Fix infinite looping if swift-format is run in a directory that doesn't contain a `.swift-format` file

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -425,17 +425,12 @@ public struct Configuration: Codable, Equatable {
       candidateDirectory.appendPathComponent("placeholder")
     }
     repeat {
-      let previousDirectory = candidateDirectory
       candidateDirectory.deleteLastPathComponent()
-      // if deleting a path component resulted in no change, terminate the loop
-      if candidateDirectory == previousDirectory {
-        break
-      }
       let candidateFile = candidateDirectory.appendingPathComponent(".swift-format")
       if FileManager.default.isReadableFile(atPath: candidateFile.path) {
         return candidateFile
       }
-    } while true
+    } while !candidateDirectory.isRoot
 
     return nil
   }
@@ -476,4 +471,16 @@ public struct NoAssignmentInExpressionsConfiguration: Codable, Equatable {
   ]
 
   public init() {}
+}
+
+fileprivate extension URL {
+  var isRoot: Bool {
+    #if os(Windows)
+    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
+    // https://github.com/swiftlang/swift-format/issues/844
+    return self.pathComponents.count == 1
+    #else
+    return self.path == "/"
+    #endif
+  }
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -17,4 +17,13 @@ final class ConfigurationTests: XCTestCase {
 
     XCTAssertEqual(defaultInitConfig, emptyJSONConfig)
   }
+
+  func testMissingConfigurationFile() {
+    #if os(Windows)
+    let path = #"C:\test.swift"#
+    #else
+    let path = "/test.swift"
+    #endif
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
 }


### PR DESCRIPTION
https://github.com/swiftlang/swift-format/pull/802 this sort of infinite looping issue on Windows but introduced it on Unix platforms where `URL.deletingLastPathComponent` on `/` returns `/..`.