### PR TITLE
Fix infinite searching for `.swift-format` file on Linux

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -480,7 +480,9 @@ fileprivate extension URL {
     // https://github.com/swiftlang/swift-format/issues/844
     return self.pathComponents.count == 1
     #else
-    return self.path == "/"
+    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
+    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
+    return self.path == "/" || self.path == ""
     #endif
   }
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -26,4 +26,21 @@ final class ConfigurationTests: XCTestCase {
     #endif
     XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
   }
+
+  func testMissingConfigurationFileInSubdirectory() {
+    #if os(Windows)
+    let path = #"C:\whatever\test.swift"#
+    #else
+    let path = "/whatever/test.swift"
+    #endif
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
+
+  func testMissingConfigurationFileMountedDirectory() throws {
+    #if !os(Windows)
+    try XCTSkipIf(true, #"\\ file mounts are only a concept on Windows"#)
+    #endif
+    let path = #"\\mount\test.swift"#
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
 }


### PR DESCRIPTION
Due to https://github.com/swiftlang/swift-foundation/issues/980, the we may end up with a `path == ""` instead of `/`.

We didn’t catch this in the test because we only end up with an empty path when searching for a `.swift-format` file from a `.swift-file` that was not at the root of a directory.