### PR TITLE
[6.0] Fix infinite searching for .swift-format file on Windows and Linux

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -328,7 +328,7 @@ public struct Configuration: Codable, Equatable {
       if FileManager.default.isReadableFile(atPath: candidateFile.path) {
         return candidateFile
       }
-    } while candidateDirectory.path != "/"
+    } while !candidateDirectory.isRoot
 
     return nil
   }
@@ -369,4 +369,18 @@ public struct NoAssignmentInExpressionsConfiguration: Codable, Equatable {
   ]
 
   public init() {}
+}
+
+fileprivate extension URL {
+  var isRoot: Bool {
+    #if os(Windows)
+    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
+    // https://github.com/swiftlang/swift-format/issues/844
+    return self.pathComponents.count == 1
+    #else
+    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
+    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
+    return self.path == "/" || self.path == ""
+    #endif
+  }
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -17,4 +17,30 @@ final class ConfigurationTests: XCTestCase {
 
     XCTAssertEqual(defaultInitConfig, emptyJSONConfig)
   }
+
+  func testMissingConfigurationFile() {
+    #if os(Windows)
+    let path = #"C:\test.swift"#
+    #else
+    let path = "/test.swift"
+    #endif
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
+
+  func testMissingConfigurationFileInSubdirectory() {
+    #if os(Windows)
+    let path = #"C:\whatever\test.swift"#
+    #else
+    let path = "/whatever/test.swift"
+    #endif
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
+
+  func testMissingConfigurationFileMountedDirectory() throws {
+    #if !os(Windows)
+    try XCTSkipIf(true, #"\\ file mounts are only a concept on Windows"#)
+    #endif
+    let path = #"\\mount\test.swift"#
+    XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
+  }
 }


### PR DESCRIPTION
- **Explanation**: Deleting path components from a URL on Windows will never end up with a path `/` because Windows has drive letters. On Linux, we end up with an empty path instead of `/` because of https://github.com/swiftlang/swift-foundation/issues/980.
- **Scope**: Directory traversal in the search for a `.swift-format` file
- **Risk**: Low, the existing logic is still in place, we just increase the number of directories that we consider root and all of those checks should be safe
- **Testing**: Add test cases, manually verified that we terminate the directory traversal on Linux and Windows
- **Issue**: https://github.com/swiftlang/swift-format/issues/847 / https://github.com/swiftlang/swift-format/issues/694 / rdar://137738047 / rdar://126948386
- **Reviewer**:   @allevato on https://github.com/swiftlang/swift-format/pull/802 and https://github.com/swiftlang/swift-format/pull/848