### PR TITLE
Make tests pass using Swift 5.9 and Swift 5.10 on Windows

### DIFF
--- a/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
+++ b/Tests/SwiftFormatTests/Rules/LintOrFormatRuleTestCase.swift
@@ -55,7 +55,7 @@ class LintOrFormatRuleTestCase: DiagnosingTestCase {
       syntax: sourceFileSyntax,
       source: unmarkedSource,
       operatorTable: OperatorTable.standardOperators,
-      assumingFileURL: URL(string: file.description)!
+      assumingFileURL: URL(fileURLWithPath: file.description)
     )
 
     // Check that pipeline produces the expected findings

--- a/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
@@ -24,14 +24,20 @@ final class FileIteratorTests: XCTestCase {
     try FileManager.default.removeItem(at: tmpdir)
   }
 
-  func testNoFollowSymlinks() {
+  func testNoFollowSymlinks() throws {
+    #if os(Windows) && compiler(<5.10)
+    try XCTSkipIf(true, "Foundation does not follow symlinks on Windows")
+    #endif
     let seen = allFilesSeen(iteratingOver: [tmpdir], followSymlinks: false)
     XCTAssertEqual(seen.count, 2)
     XCTAssertTrue(seen.contains { $0.hasSuffix("project/real1.swift") })
     XCTAssertTrue(seen.contains { $0.hasSuffix("project/real2.swift") })
   }
 
-  func testFollowSymlinks() {
+  func testFollowSymlinks() throws {
+    #if os(Windows) && compiler(<5.10)
+    try XCTSkipIf(true, "Foundation does not follow symlinks on Windows")
+    #endif
     let seen = allFilesSeen(iteratingOver: [tmpdir], followSymlinks: true)
     XCTAssertEqual(seen.count, 3)
     XCTAssertTrue(seen.contains { $0.hasSuffix("project/real1.swift") })
@@ -40,7 +46,10 @@ final class FileIteratorTests: XCTestCase {
     XCTAssertTrue(seen.contains { $0.hasSuffix("project/.hidden.swift") })
   }
 
-  func testTraversesHiddenFilesIfExplicitlySpecified() {
+  func testTraversesHiddenFilesIfExplicitlySpecified() throws {
+    #if os(Windows) && compiler(<5.10)
+    try XCTSkipIf(true, "Foundation does not follow symlinks on Windows")
+    #endif
     let seen = allFilesSeen(
       iteratingOver: [tmpURL("project/.build"), tmpURL("project/.hidden.swift")],
       followSymlinks: false


### PR DESCRIPTION
- We need to disable a few file traversal tests because of Foundation issues
- We need to use `URL(fileURLWithPath:)` instead of `URL(string:)` to construct a URL from a string