### PR TITLE
Fix formatting issue with IfConfigDecl/ImportDecl interaction.

### DIFF
--- a/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/IfConfigTests.swift
@@ -557,4 +557,19 @@ final class IfConfigTests: PrettyPrintTestCase {
     configuration.indentConditionalCompilationBlocks = false
     assertPrettyPrintEqual(input: input, expected: input, linelength: 45, configuration: configuration)
   }
+
+  func testIfConfigDeclPartOfImport() {
+    let input =
+      """
+      #if os(Foo)
+      @_spiOnly
+      #endif
+      @_spi(Foo) import Foundation
+      
+      """
+    var configuration = Configuration.forTesting
+    configuration.indentConditionalCompilationBlocks = false
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 80, configuration: configuration)
+
+  }
 }


### PR DESCRIPTION
The ImportDecl syntax node disables all line breaks (other than `hard`). This creates code that fails to compile when `#if`/`#endif` are involved (see example), removing all the line breaks after the `#if <clause>` as well as the `#endif`. Switching to hard line breaks would certainly work but feels a bit heavy handed and could end up with extra line breaks in other scenarios.
