### PR TITLE
Fix support for `FileIterator` when working directory is `/`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       license_header_check_enabled: false
       license_header_check_project_name: "Swift.org"
+      api_breakage_check_allowlist_path: "api-breakages.txt"

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -486,17 +486,3 @@ public struct NoAssignmentInExpressionsConfiguration: Codable, Equatable {
 
   public init() {}
 }
-
-fileprivate extension URL {
-  var isRoot: Bool {
-    #if os(Windows)
-    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
-    // https://github.com/swiftlang/swift-format/issues/844
-    return self.pathComponents.count <= 1
-    #else
-    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
-    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
-    return self.path == "/" || self.path == ""
-    #endif
-  }
-}

--- a/Sources/SwiftFormat/CMakeLists.txt
+++ b/Sources/SwiftFormat/CMakeLists.txt
@@ -97,7 +97,8 @@ add_library(SwiftFormat
   Rules/UseTripleSlashForDocumentationComments.swift
   Rules/UseWhereClausesInForLoops.swift
   Rules/ValidateDocumentationComments.swift
-  Utilities/FileIterator.swift)
+  Utilities/FileIterator.swift
+  Utilities/URL+isRoot.swift)
 target_link_libraries(SwiftFormat PUBLIC
   SwiftMarkdown::Markdown
   SwiftSyntax::SwiftSyntax

--- a/Sources/SwiftFormat/Utilities/URL+isRoot.swift
+++ b/Sources/SwiftFormat/Utilities/URL+isRoot.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension URL {
+  @_spi(Testing) public var isRoot: Bool {
+    #if os(Windows)
+    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
+    // https://github.com/swiftlang/swift-format/issues/844
+    var pathComponents = self.pathComponents
+    if pathComponents.first == "/" {
+      // Canonicalize `/C:/` to `C:/`.
+      pathComponents = Array(pathComponents.dropFirst())
+    }
+    return pathComponents.count <= 1
+    #else
+    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
+    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
+    return self.path == "/" || self.path == ""
+    #endif
+  }
+}

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -1,0 +1,4 @@
+6.2
+---
+
+API breakage: constructor FileIterator.init(urls:followSymlinks:) has been removed


### PR DESCRIPTION
Added an additional check that tests to see if the working directory is root to solve #862.

### Simple Fix
Simple check that looks to see if the working directory is root.
```swift
 let relativePath =
          path.hasPrefix(workingDirectory.path) && FileManager.default.currentDirectoryPath != "/"
          ? String(path.dropFirst(workingDirectory.path.count + 1))
          : path
        output =
          URL(fileURLWithPath: relativePath, isDirectory: false, relativeTo: workingDirectory)
``` 
#
### Testing

I couldn't find a non-intrusive way to simulate changing the working directory of the unit tests. This path remains uncovered as a result of that.

Manual testing with the debug build. The behavior of #862 is resolved.

**Works from `/tmp`**
```shell
/tmp % pwd
/tmp

/tmp % ls -l testsf/*.swift 
-rw-r--r--@ 1 josh.wisenbaker  wheel  308 Nov  4  2022 testsf/bp.swift

/tmp % <trimmed>/Products/Debug/swift-format lint -rs .
bp.swift:1:31: warning: [GroupNumericLiterals] group every 3 digits in this decimal literal using a '_' separator
``` 


**Now works from `/` as well**
```shell 
% cd /           
/ % pwd                 
/

/ % ls -l /tmp/testsf/*.swift
-rw-r--r--@ 1 josh.wisenbaker  wheel  308 Nov  4  2022 /tmp/testsf/bp.swift

/ % <trimmed>/Products/Debug/swift-format lint -rs /tmp/testsf
/private/tmp/testsf/bp.swift:1:31: warning: [GroupNumericLiterals] group every 3 digits in this decimal literal using a '_' separator
```

I'll need to spin up a linux VM to test if we get relative paths when running from root.