### PR TITLE
Prepare for integer generics with new generic argument node

### DIFF
--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -47,12 +47,10 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch node.name.text {
     case "Array":
-      guard let argument = genericArgumentList.firstAndOnly,
-            case .type(let typeArgument) = argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
         newNode = nil
         break
       }
-
       newNode = shorthandArrayType(
         element: typeArgument,
         leadingTrivia: leadingTrivia,
@@ -60,9 +58,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       )
 
     case "Dictionary":
-      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
-            case .type(let type0Argument) = arguments.0.argument,
-            caes .type(let type1Argument) = arguments.1.argument else {
+      guard case (.type(let type0Argument), .type(let type1Argument)) = exactlyTwoChildren(of: genericArgumentList)
+      else {
         newNode = nil
         break
       }
@@ -78,8 +75,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         newNode = nil
         break
       }
-      guard let argument = genericArgumentList.firstAndOnly,
-            case .type(let typeArgument) = argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
         newNode = nil
         break
       }
@@ -142,8 +138,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch expression.baseName.text {
     case "Array":
-      guard let argument = genericArgumentList.firstAndOnly,
-            case .type(let typeArgument) = argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
         newNode = nil
         break
       }
@@ -155,9 +150,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(arrayTypeExpr)
 
     case "Dictionary":
-      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
-            case .type(let type0Argument) = arguments.0.argument,
-            case .type(let type1Argument) = arguments.1.argument else {
+      guard case (.type(let type0Argument), .type(let type1Argument)) = exactlyTwoChildren(of: genericArgumentList)
+      else {
         newNode = nil
         break
       }
@@ -171,8 +165,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(dictTypeExpr)
 
     case "Optional":
-      guard let argument = genericArgumentList.firstAndOnly,
-            case .type(let typeArgument) = argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
         newNode = nil
         break
       }

--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -47,7 +47,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch node.name.text {
     case "Array":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly?.argument else {
         newNode = nil
         break
       }
@@ -76,7 +76,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         newNode = nil
         break
       }
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly?.argument else {
         newNode = nil
         break
       }
@@ -139,7 +139,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch expression.baseName.text {
     case "Array":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly?.argument else {
         newNode = nil
         break
       }
@@ -167,7 +167,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(dictTypeExpr)
 
     case "Optional":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly?.argument else {
         newNode = nil
         break
       }

--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -47,24 +47,28 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch node.name.text {
     case "Array":
-      guard let typeArgument = genericArgumentList.firstAndOnly else {
+      guard let argument = genericArgumentList.firstAndOnly,
+            case .type(let typeArgument) = argument else {
         newNode = nil
         break
       }
+
       newNode = shorthandArrayType(
-        element: typeArgument.argument,
+        element: typeArgument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia
       )
 
     case "Dictionary":
-      guard let typeArguments = exactlyTwoChildren(of: genericArgumentList) else {
+      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
+            case .type(let type0Argument) = arguments.0.argument,
+            caes .type(let type1Argument) = arguments.1.argument else {
         newNode = nil
         break
       }
       newNode = shorthandDictionaryType(
-        key: typeArguments.0.argument,
-        value: typeArguments.1.argument,
+        key: type0Argument,
+        value: type1Argument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia
       )
@@ -74,12 +78,13 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         newNode = nil
         break
       }
-      guard let typeArgument = genericArgumentList.firstAndOnly else {
+      guard let argument = genericArgumentList.firstAndOnly,
+            case .type(let typeArgument) = argument else {
         newNode = nil
         break
       }
       newNode = shorthandOptionalType(
-        wrapping: typeArgument.argument,
+        wrapping: typeArgument,
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia
       )
@@ -137,25 +142,28 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch expression.baseName.text {
     case "Array":
-      guard let typeArgument = genericArgumentList.firstAndOnly else {
+      guard let argument = genericArgumentList.firstAndOnly,
+            case .type(let typeArgument) = argument else {
         newNode = nil
         break
       }
       let arrayTypeExpr = makeArrayTypeExpression(
-        elementType: typeArgument.argument,
+        elementType: typeArgument,
         leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
         rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia)
       )
       newNode = ExprSyntax(arrayTypeExpr)
 
     case "Dictionary":
-      guard let typeArguments = exactlyTwoChildren(of: genericArgumentList) else {
+      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
+            case .type(let type0Argument) = arguments.0.argument,
+            case .type(let type1Argument) = arguments.1.argument else {
         newNode = nil
         break
       }
       let dictTypeExpr = makeDictionaryTypeExpression(
-        keyType: typeArguments.0.argument,
-        valueType: typeArguments.1.argument,
+        keyType: type0Argument,
+        valueType: type1Argument,
         leftSquare: TokenSyntax.leftSquareToken(leadingTrivia: leadingTrivia),
         colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
         rightSquare: TokenSyntax.rightSquareToken(trailingTrivia: trailingTrivia)
@@ -163,12 +171,13 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(dictTypeExpr)
 
     case "Optional":
-      guard let typeArgument = genericArgumentList.firstAndOnly else {
+      guard let argument = genericArgumentList.firstAndOnly,
+            case .type(let typeArgument) = argument else {
         newNode = nil
         break
       }
       let optionalTypeExpr = makeOptionalTypeExpression(
-        wrapping: typeArgument.argument,
+        wrapping: typeArgument,
         leadingTrivia: leadingTrivia,
         questionMark: TokenSyntax.postfixQuestionMarkToken(trailingTrivia: trailingTrivia)
       )

--- a/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
+++ b/Sources/SwiftFormat/Rules/UseShorthandTypeNames.swift
@@ -47,7 +47,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch node.name.text {
     case "Array":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
         newNode = nil
         break
       }
@@ -58,7 +58,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       )
 
     case "Dictionary":
-      guard case (.type(let type0Argument), .type(let type1Argument)) = exactlyTwoChildren(of: genericArgumentList)
+      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
+        case (.type(let type0Argument), .type(let type1Argument)) = (arguments.0.argument, arguments.1.argument)
       else {
         newNode = nil
         break
@@ -75,7 +76,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
         newNode = nil
         break
       }
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
         newNode = nil
         break
       }
@@ -138,7 +139,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
 
     switch expression.baseName.text {
     case "Array":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
         newNode = nil
         break
       }
@@ -150,7 +151,8 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(arrayTypeExpr)
 
     case "Dictionary":
-      guard case (.type(let type0Argument), .type(let type1Argument)) = exactlyTwoChildren(of: genericArgumentList)
+      guard let arguments = exactlyTwoChildren(of: genericArgumentList),
+        case (.type(let type0Argument), .type(let type1Argument)) = (arguments.0.argument, arguments.1.argument)
       else {
         newNode = nil
         break
@@ -165,7 +167,7 @@ public final class UseShorthandTypeNames: SyntaxFormatRule {
       newNode = ExprSyntax(dictTypeExpr)
 
     case "Optional":
-      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly else {
+      guard case .type(let typeArgument) = genericArgumentList.firstAndOnly.argument else {
         newNode = nil
         break
       }


### PR DESCRIPTION
With https://github.com/swiftlang/swift-syntax/pull/2859, there will be a new generic argument node that you need to switch over.