### PR TITLE
Fix tests when building swift-format using Swift 6.0.2

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -478,7 +478,7 @@ fileprivate extension URL {
     #if os(Windows)
     // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
     // https://github.com/swiftlang/swift-format/issues/844
-    return self.pathComponents.count == 1
+    return self.pathComponents.count <= 1
     #else
     // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
     // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.


### PR DESCRIPTION
When traversing the file URL with Foundation from Swift 6.0.2, you get the following components
- `["/", "C:", "test.swift"]`
- `["/", "C:"]`
- `[]`

The component count never reaches 1.

Foundation from Swift 6.1 goes
- `["/", "C:", "test.swift"]`
- `["/", "C:"]`
- `["/"]`

Cover both cases by checking for `<= 1` instead of `== 1`