### PR TITLE
Add `--enable-experimental-feature` to enable those features in the parser.

### DIFF
--- a/Sources/SwiftFormat/API/SwiftFormatError.swift
+++ b/Sources/SwiftFormat/API/SwiftFormatError.swift
@@ -10,10 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import SwiftSyntax
 
 /// Errors that can be thrown by the `SwiftFormatter` and `SwiftLinter` APIs.
-public enum SwiftFormatError: Error {
+public enum SwiftFormatError: LocalizedError {
 
   /// The requested file was not readable or it did not exist.
   case fileNotReadable
@@ -23,4 +24,23 @@ public enum SwiftFormatError: Error {
 
   /// The file contains invalid or unrecognized Swift syntax and cannot be handled safely.
   case fileContainsInvalidSyntax
+
+  /// The requested experimental feature name was not recognized by the parser.
+  case unrecognizedExperimentalFeature(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .fileNotReadable:
+      return "file is not readable or does not exist"
+    case .isDirectory:
+      return "requested path is a directory, not a file"
+    case .fileContainsInvalidSyntax:
+      return "file contains invalid Swift syntax"
+    case .unrecognizedExperimentalFeature(let name):
+      return "experimental feature '\(name)' was not recognized by the Swift parser"
+    }
+  }
 }
+
+extension SwiftFormatError: Equatable {}
+extension SwiftFormatError: Hashable {}

--- a/Sources/SwiftFormat/API/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/API/SwiftFormatter.swift
@@ -89,6 +89,10 @@ public final class SwiftFormatter {
   ///     which is associated with any diagnostics emitted during formatting. If this is nil, a
   ///     dummy value will be used.
   ///   - selection: The ranges to format
+  ///   - experimentalFeatures: The set of experimental features that should be enabled in the
+  ///     parser. These names must be from the set of parser-recognized experimental language
+  ///     features in `SwiftParser`'s `Parser.ExperimentalFeatures` enum, which match the spelling
+  ///     defined in the compiler's `Features.def` file.
   ///   - outputStream: A value conforming to `TextOutputStream` to which the formatted output will
   ///     be written.
   ///   - parsingDiagnosticHandler: An optional callback that will be notified if there are any
@@ -98,6 +102,7 @@ public final class SwiftFormatter {
     source: String,
     assumingFileURL url: URL?,
     selection: Selection,
+    experimentalFeatures: Set<String> = [],
     to outputStream: inout Output,
     parsingDiagnosticHandler: ((Diagnostic, SourceLocation) -> Void)? = nil
   ) throws {
@@ -110,6 +115,7 @@ public final class SwiftFormatter {
       source: source,
       operatorTable: .standardOperators,
       assumingFileURL: url,
+      experimentalFeatures: experimentalFeatures,
       parsingDiagnosticHandler: parsingDiagnosticHandler
     )
     try format(

--- a/Sources/SwiftFormat/API/SwiftLinter.swift
+++ b/Sources/SwiftFormat/API/SwiftLinter.swift
@@ -81,12 +81,17 @@ public final class SwiftLinter {
   /// - Parameters:
   ///   - source: The Swift source code to be linted.
   ///   - url: A file URL denoting the filename/path that should be assumed for this source code.
+  ///   - experimentalFeatures: The set of experimental features that should be enabled in the
+  ///     parser. These names must be from the set of parser-recognized experimental language
+  ///     features in `SwiftParser`'s `Parser.ExperimentalFeatures` enum, which match the spelling
+  ///     defined in the compiler's `Features.def` file.
   ///   - parsingDiagnosticHandler: An optional callback that will be notified if there are any
   ///     errors when parsing the source code.
   /// - Throws: If an unrecoverable error occurs when formatting the code.
   public func lint(
     source: String,
     assumingFileURL url: URL,
+    experimentalFeatures: Set<String> = [],
     parsingDiagnosticHandler: ((Diagnostic, SourceLocation) -> Void)? = nil
   ) throws {
     // If the file or input string is completely empty, do nothing. This prevents even a trailing
@@ -98,6 +103,7 @@ public final class SwiftLinter {
       source: source,
       operatorTable: .standardOperators,
       assumingFileURL: url,
+      experimentalFeatures: experimentalFeatures,
       parsingDiagnosticHandler: parsingDiagnosticHandler
     )
     try lint(

--- a/Sources/_SwiftFormatTestSupport/Parsing.swift
+++ b/Sources/_SwiftFormatTestSupport/Parsing.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(ExperimentalLanguageFeatures) import SwiftParser
+import SwiftSyntax
+import XCTest
+
+extension Parser {
+  /// Parses the given source string and returns the corresponding `SourceFileSyntax` node.
+  ///
+  /// - Parameters:
+  ///   - source: The source text to parse.
+  ///   - experimentalFeatures: The set of experimental features that should be enabled in the
+  ///     parser.
+  @_spi(Testing)
+  public static func parse(
+    source: String,
+    experimentalFeatures: Parser.ExperimentalFeatures
+  ) -> SourceFileSyntax {
+    var source = source
+    return source.withUTF8 { sourceBytes in
+      parse(
+        source: sourceBytes,
+        experimentalFeatures: experimentalFeatures
+      )
+    }
+  }
+}

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -56,6 +56,7 @@ class FormatFrontend: Frontend {
           source: source,
           assumingFileURL: url,
           selection: fileToProcess.selection,
+          experimentalFeatures: Set(lintFormatOptions.experimentalFeatures),
           to: &buffer,
           parsingDiagnosticHandler: diagnosticHandler
         )
@@ -69,15 +70,11 @@ class FormatFrontend: Frontend {
           source: source,
           assumingFileURL: url,
           selection: fileToProcess.selection,
+          experimentalFeatures: Set(lintFormatOptions.experimentalFeatures),
           to: &stdoutStream,
           parsingDiagnosticHandler: diagnosticHandler
         )
       }
-    } catch SwiftFormatError.fileNotReadable {
-      diagnosticsEngine.emitError(
-        "Unable to format \(url.relativePath): file is not readable or does not exist."
-      )
-      return
     } catch SwiftFormatError.fileContainsInvalidSyntax {
       guard !lintFormatOptions.ignoreUnparsableFiles else {
         guard !inPlace else {
@@ -87,10 +84,10 @@ class FormatFrontend: Frontend {
         stdoutStream.write(source)
         return
       }
-      // Otherwise, relevant diagnostics about the problematic nodes have been emitted.
-      return
+      // Otherwise, relevant diagnostics about the problematic nodes have already been emitted; we
+      // don't need to print anything else.
     } catch {
-      diagnosticsEngine.emitError("Unable to format \(url.relativePath): \(error)")
+      diagnosticsEngine.emitError("Unable to format \(url.relativePath): \(error.localizedDescription).")
     }
   }
 }

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -98,6 +98,15 @@ struct LintFormatOptions: ParsableArguments {
   )
   var followSymlinks: Bool = false
 
+  @Option(
+    name: .customLong("enable-experimental-feature"),
+    help: """
+      The name of an experimental swift-syntax parser feature that should be enabled by \
+      swift-format. Multiple features can be enabled by specifying this flag multiple times.
+      """
+  )
+  var experimentalFeatures: [String] = []
+
   /// The list of paths to Swift source files that should be formatted or linted.
   @Argument(help: "Zero or more input filenames.")
   var paths: [String] = []

--- a/Tests/SwiftFormatTests/PrettyPrint/ValueGenericsTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ValueGenericsTests.swift
@@ -1,0 +1,46 @@
+@_spi(ExperimentalLanguageFeatures) import SwiftParser
+
+final class ValueGenericsTests: PrettyPrintTestCase {
+  func testValueGenericDeclaration() {
+    let input = "struct Foo<let n: Int> { static let bar = n }"
+    let expected = """
+      struct Foo<
+        let n: Int
+      > {
+        static let bar = n
+      }
+
+      """
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 20,
+      experimentalFeatures: [.valueGenerics]
+    )
+  }
+
+  func testValueGenericTypeUsage() {
+    let input =
+      """
+      let v1: Vector<100, Int>
+      let v2 = Vector<100, Int>()
+      """
+    let expected = """
+      let v1:
+        Vector<
+          100, Int
+        >
+      let v2 =
+        Vector<
+          100, Int
+        >()
+
+      """
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 15,
+      experimentalFeatures: [.valueGenerics]
+    )
+  }
+}


### PR DESCRIPTION
Also add a couple small tests for value generics to exercise the capability in tests, and I took the opportunity to clean up some error handling with the addition of this new user-facing error when an experimental feature isn't recognized.

I'm passing the experimental features through as strings deeper than I'd like, but trying to resolve them to the `Parser.ExperimentalFeatures` type higher in the stack causes more problems since that type is behind an `@_spi`. To prevent SPI leakage in swift-format's public interfaces (and thus require those interfaces to also have their own `@_spi`-restricted overloads), just leave them as a `Set<String>` until we call `Parser.parse` directly.

This PR requires https://github.com/swiftlang/swift-syntax/pull/2895.

Fixes #875.