### PR TITLE
[cmake] Set up rpath for macOS

### DIFF
--- a/Sources/swift-format/CMakeLists.txt
+++ b/Sources/swift-format/CMakeLists.txt
@@ -33,4 +33,7 @@ target_link_libraries(swift-format PRIVATE
   SwiftParser
   SwiftSyntax)
 
+set_target_properties(swift-format PROPERTIES
+  INSTALL_RPATH "$<$<PLATFORM_ID:Darwin>:@executable_path/../lib/swift/macosx;@executable_path/../lib/swift/host;@executable_path/../lib/swift/host/compiler>")
+
 _install_target(swift-format)


### PR DESCRIPTION
This set up the `INSTALL_RPATH` property for the `swift-format` binary, resulting in a binary that is directly usable post-installation.