### PR TITLE
PrettyPrinter reports wrong line LineNumbersTests

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrintBuffer.swift
@@ -118,7 +118,20 @@ struct PrettyPrintBuffer {
     writeRaw(text)
     consecutiveNewlineCount = 0
     pendingSpaces = 0
-    column += text.count
+
+    // In case of comments, we may get a multi-line string.
+    // To account for that case, we need to correct the lineNumber count.
+    // The new column is only the position within the last line.
+    let lines = text.split(separator: "\n")
+    lineNumber += lines.count - 1
+    if lines.count > 1 {
+      // in case we have inserted new lines, we need to reset the column
+      column = lines.last?.count ?? 0
+    } else {
+      // in case it is an end of line comment or a single line comment,
+      // we just add to the current column
+      column += lines.last?.count ?? 0
+    }
   }
 
   /// Request that the given number of spaces be printed out before the next text token.

--- a/Tests/SwiftFormatTests/PrettyPrint/LineNumbersTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/LineNumbersTests.swift
@@ -1,0 +1,84 @@
+import SwiftFormat
+import _SwiftFormatTestSupport
+
+final class LineNumbersTests: PrettyPrintTestCase {
+  func testLineNumbers() {
+    let input =
+      """
+      final class A {
+        @Test func b() throws {
+          doSomethingInAFunctionWithAVeryLongName()  1️⃣// Here we have a very long comment that should not be here because it is far too long
+        }
+      }
+      """
+
+    let expected =
+      """
+      final class A {
+        @Test func b() throws {
+          doSomethingInAFunctionWithAVeryLongName()  // Here we have a very long comment that should not be here because it is far too long
+        }
+      }
+
+      """
+
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 120,
+      whitespaceOnly: true,
+      findings: [
+        FindingSpec("1️⃣", message: "move end-of-line comment that exceeds the line length")
+      ]
+    )
+  }
+
+  func testLineNumbersWithComments() {
+    let input =
+      """
+      // Copyright (C) 2024 My Coorp. All rights reserved.
+      //
+      // This document is the property of My Coorp.
+      // It is considered confidential and proprietary.
+      //
+      // This document may not be reproduced or transmitted in any form,
+      // in whole or in part, without the express written permission of
+      // My Coorp.
+
+      final class A {
+        @Test func b() throws {
+          doSomethingInAFunctionWithAVeryLongName()  1️⃣// Here we have a very long comment that should not be here because it is far too long
+        }
+      }
+      """
+
+    let expected =
+      """
+      // Copyright (C) 2024 My Coorp. All rights reserved.
+      //
+      // This document is the property of My Coorp.
+      // It is considered confidential and proprietary.
+      //
+      // This document may not be reproduced or transmitted in any form,
+      // in whole or in part, without the express written permission of
+      // My Coorp.
+
+      final class A {
+        @Test func b() throws {
+          doSomethingInAFunctionWithAVeryLongName()  // Here we have a very long comment that should not be here because it is far too long
+        }
+      }
+
+      """
+
+    assertPrettyPrintEqual(
+      input: input,
+      expected: expected,
+      linelength: 120,
+      whitespaceOnly: true,
+      findings: [
+        FindingSpec("1️⃣", message: "move end-of-line comment that exceeds the line length")
+      ]
+    )
+  }
+}


### PR DESCRIPTION
This is to reproduce issue #882.

I am not sure if the fix is done in the right place. With my change every string is checked for new lines, which might be not necessary and comes at a slight cost. Maybe there is another, better place to fix this.