### PR TITLE
Use dockerless Windows jobs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,8 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
Dockerless Windows is 5-10 minutes faster than Docker on Windows