### PR TITLE
Bugfixes for the publish release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -99,6 +99,7 @@ jobs:
       matrix:
         release: [true, false]
     with:
+      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
       linux_pre_build_command: |
         git config --global --add safe.directory "$(realpath .)"
         git config --local user.name 'swift-ci'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -116,8 +116,8 @@ jobs:
         # fatal: empty ident name (for <>) not allowed
         cmd /c "type $env:TEMP\patch.diff | git am || (exit /b 1)"
       # We require that releases of swift-format build without warnings
-      linux_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' }}
-      windows_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' }}
+      linux_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
+      windows_build_command: swift test -Xswiftc -warnings-as-errors ${{ matrix.release && '-c release' || '' }}
   create_tag:
     name: Create Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Ensure we don’t emit `false` into the command line when `matrix.release` is false
- Use dockerless Windows because it’s faster