### PR TITLE
Fix comment length computation

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -67,9 +67,9 @@ struct Comment {
 
     switch kind {
     case .line, .docLine:
+      self.length = text.count
       self.text = [text]
       self.text[0].removeFirst(kind.prefixLength)
-      self.length = self.text.reduce(0, { $0 + $1.count + kind.prefixLength + 1 })
 
     case .block, .docBlock:
       var fulltext: String = text

--- a/Tests/SwiftFormatTests/PrettyPrint/CommentTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommentTests.swift
@@ -1009,6 +1009,29 @@ final class CommentTests: PrettyPrintTestCase {
     )
   }
 
+  // Tests that "end of line" comments are flagged only when they exceed the configured line length.
+  func testDiagnoseMoveEndOfLineCommentAroundBoundary() {
+    assertPrettyPrintEqual(
+      input: """
+        x  // 789
+        x  // 7890
+        x  1️⃣// 78901
+
+        """,
+      expected: """
+        x  // 789
+        x  // 7890
+        x  // 78901
+
+        """,
+      linelength: 10,
+      whitespaceOnly: true,
+      findings: [
+        FindingSpec("1️⃣", message: "move end-of-line comment that exceeds the line length")
+      ]
+    )
+  }
+
   func testLineWithDocLineComment() {
     // none of these should be merged if/when there is comment formatting
     let input =


### PR DESCRIPTION
Resolved an issue where "end of line" comments matching the configured line length were incorrectly flagged as exceeding it.