### PR TITLE
Add Swift package index yml file

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,11 @@
+# This is manifest file for the Swift Package Index for it to
+# auto-generate and host DocC documentation.
+# For reference see https://swiftpackageindex.com/swiftpackageindex/spimanifest/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index.
+
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+        # First item in the list is the "landing" (default) target
+        - SwiftFormat
+      custom_documentation_parameters: [--experimental-skip-synthesized-symbols]

--- a/Sources/SwiftFormat/API/SwiftFormatter.swift
+++ b/Sources/SwiftFormat/API/SwiftFormatter.swift
@@ -45,7 +45,7 @@ public final class SwiftFormatter {
   /// This form of the `format` function automatically folds expressions using the default operator
   /// set defined in Swift. If you need more control over this—for example, to provide the correct
   /// precedence relationships for custom operators—you must parse and fold the syntax tree
-  /// manually and then call ``format(syntax:assumingFileURL:to:)``.
+  /// manually and then call ``format(syntax:source:operatorTable:assumingFileURL:selection:to:)``.
   ///
   /// - Parameters:
   ///   - url: The URL of the file containing the code to format.
@@ -81,7 +81,7 @@ public final class SwiftFormatter {
   /// This form of the `format` function automatically folds expressions using the default operator
   /// set defined in Swift. If you need more control over this—for example, to provide the correct
   /// precedence relationships for custom operators—you must parse and fold the syntax tree
-  /// manually and then call ``format(syntax:assumingFileURL:to:)``.
+  /// manually and then call ``format(syntax:source:operatorTable:assumingFileURL:selection:to:)``.
   ///
   /// - Parameters:
   ///   - source: The Swift source code to be formatted.

--- a/Sources/SwiftFormat/API/SwiftLinter.swift
+++ b/Sources/SwiftFormat/API/SwiftLinter.swift
@@ -45,7 +45,7 @@ public final class SwiftLinter {
   /// This form of the `lint` function automatically folds expressions using the default operator
   /// set defined in Swift. If you need more control over this—for example, to provide the correct
   /// precedence relationships for custom operators—you must parse and fold the syntax tree
-  /// manually and then call ``lint(syntax:assumingFileURL:)``.
+  /// manually and then call ``lint(syntax:source:operatorTable:assumingFileURL:)``.
   ///
   /// - Parameters:
   ///   - url: The URL of the file containing the code to format.
@@ -76,7 +76,7 @@ public final class SwiftLinter {
   /// This form of the `lint` function automatically folds expressions using the default operator
   /// set defined in Swift. If you need more control over this—for example, to provide the correct
   /// precedence relationships for custom operators—you must parse and fold the syntax tree
-  /// manually and then call ``lint(syntax:assumingFileURL:)``.
+  /// manually and then call ``lint(syntax:source:operatorTable:assumingFileURL:)``.
   ///
   /// - Parameters:
   ///   - source: The Swift source code to be linted.
@@ -124,6 +124,7 @@ public final class SwiftLinter {
   ///
   /// - Parameters:
   ///   - syntax: The Swift syntax tree to be converted to be linted.
+  ///   - source: The Swift source code to be linted.
   ///   - operatorTable: The table that defines the operators and their precedence relationships.
   ///     This must be the same operator table that was used to fold the expressions in the `syntax`
   ///     argument.


### PR DESCRIPTION
This PR will the spi.yml file, so Swift Package Index can build the documentation.

I was thinking of only adding this, and then in follow up PR's add more markdown files, so like documentation for rules and configuration can be found easily. 