### PR TITLE
One blank line between declarations

### DIFF
--- a/Sources/SwiftFormat/API/Configuration+Default.swift
+++ b/Sources/SwiftFormat/API/Configuration+Default.swift
@@ -42,5 +42,6 @@ extension Configuration {
     self.multiElementCollectionTrailingCommas = true
     self.reflowMultilineStringLiterals = .never
     self.indentBlankLines = false
+    self.alwaysBreakOnNewScopes = false
   }
 }

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -47,6 +47,7 @@ public struct Configuration: Codable, Equatable {
     case multiElementCollectionTrailingCommas
     case reflowMultilineStringLiterals
     case indentBlankLines
+    case alwaysBreakOnNewScopes
   }
 
   /// A dictionary containing the default enabled/disabled states of rules, keyed by the rules'
@@ -268,6 +269,9 @@ public struct Configuration: Codable, Equatable {
   /// If false (the default), the whitespace in blank lines will be removed entirely.
   public var indentBlankLines: Bool
 
+  /// Determines whether to always break on new scopes.
+  public var alwaysBreakOnNewScopes: Bool
+
   /// Creates a new `Configuration` by loading it from a configuration file.
   public init(contentsOf url: URL) throws {
     let data = try Data(contentsOf: url)
@@ -383,6 +387,10 @@ public struct Configuration: Codable, Equatable {
       )
       ?? defaults.indentBlankLines
 
+    self.alwaysBreakOnNewScopes =
+      try container.decodeIfPresent(Bool.self, forKey: .alwaysBreakOnNewScopes)
+      ?? false
+
     // If the `rules` key is not present at all, default it to the built-in set
     // so that the behavior is the same as if the configuration had been
     // default-initialized. To get an empty rules dictionary, one can explicitly
@@ -422,6 +430,7 @@ public struct Configuration: Codable, Equatable {
     try container.encode(multiElementCollectionTrailingCommas, forKey: .multiElementCollectionTrailingCommas)
     try container.encode(reflowMultilineStringLiterals, forKey: .reflowMultilineStringLiterals)
     try container.encode(rules, forKey: .rules)
+    try container.encode(alwaysBreakOnNewScopes, forKey: .alwaysBreakOnNewScopes)
   }
 
   /// Returns the URL of the configuration file that applies to the given file or directory.

--- a/Tests/SwiftFormatTests/PrettyPrint/AlwaysBreakOnNewScopesTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AlwaysBreakOnNewScopesTests.swift
@@ -1,0 +1,91 @@
+import SwiftFormat
+
+final class AlwaysBreakOnNewScopesTests: PrettyPrintTestCase {
+  func testAlwaysBreakOnNewScopesEnabled() {
+    let input =
+      """
+      class A {
+        func foo() -> Int { return 1 }
+      }
+      """
+
+    let expected =
+      """
+      class A {
+        func foo() -> Int {
+          return 1
+        }
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.alwaysBreakOnNewScopes = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+
+  func testAlwaysBreakOnNewScopesDisabled() {
+    let input =
+      """
+      class A {
+        func foo() -> Int { return 1 }
+      }
+      """
+
+    let expected =
+      """
+      class A {
+        func foo() -> Int { return 1 }
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.alwaysBreakOnNewScopes = false
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+
+  func testAlwaysBreakOnNewScopesUnlessScopeIsEmpty() {
+    let input =
+      """
+      class A {
+        func foo() -> Int { }
+      }
+      """
+
+    let expected =
+      """
+      class A {
+        func foo() -> Int {}
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.alwaysBreakOnNewScopes = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+
+  func testAlwaysBreakOnNewScopesNestedScopes() {
+    let input =
+      """
+      class A {
+        func foo() -> Int { if true { 1 } else { 2 } }
+      }
+      """
+
+    let expected =
+      """
+      class A {
+        func foo() -> Int {
+          if true {
+            1
+          } else {
+            2
+          }
+        }
+      }
+
+      """
+    var config = Configuration.forTesting
+    config.alwaysBreakOnNewScopes = true
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80, configuration: config)
+  }
+}


### PR DESCRIPTION
This adds a new configuration options to make the pretty printer add a blank line between declarations that are either multiline, or have differing declaration modifiers. This works at the file scope as well. Here's an example:

```swift
typealias A = Int
typealias B = String
class A {
  private static var x1: Int
  private static var x2: Int
  var y1: Int
  var y2: Int
  private var z1: Int
  private var z2: Int
  static var w1: Int
  static var w2: Int
}

// becomes this:

typealias A = Int
typealias B = String
+
class A {
  private static var x1: Int
  private static var x2: Int
+
  var y1: Int
  var y2: Int
+
  private var z1: Int
  private var z2: Int
+
  static var w1: Int
  static var w2: Int
}
```