### PR TITLE
Gradually deprecate running swift-format without input paths; require '-' for stdin in the future

### DIFF
--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -97,7 +97,23 @@ class Frontend {
 
   /// Runs the linter or formatter over the inputs.
   final func run() {
-    if lintFormatOptions.paths.isEmpty {
+    if lintFormatOptions.paths == ["-"] {
+      processStandardInput()
+    } else if lintFormatOptions.paths.isEmpty {
+      diagnosticsEngine.emitWarning(
+        """
+        Running swift-format without input paths is deprecated and will be removed in the future.
+
+        Please update your invocation to do either of the following:
+
+        - Pass `-` to read from stdin (e.g., `cat MyFile.swift | swift-format -`).
+        - Pass one or more paths to Swift source files or directories containing
+          Swift source files. When passing directories, make sure to include the
+          `--recursive` flag.
+
+        For more information, use the `--help` option.
+        """
+      )
       processStandardInput()
     } else {
       processURLs(

--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -108,7 +108,7 @@ struct LintFormatOptions: ParsableArguments {
   var experimentalFeatures: [String] = []
 
   /// The list of paths to Swift source files that should be formatted or linted.
-  @Argument(help: "Zero or more input filenames.")
+  @Argument(help: "Zero or more input filenames. Use `-` for stdin.")
   var paths: [String] = []
 
   @Flag(help: .hidden) var debugDisablePrettyPrint: Bool = false


### PR DESCRIPTION
As discussed in #871 and in this forum thread [Default behavior of “swift format”](https://forums.swift.org/t/default-behavior-of-swift-format/74314), waiting for stdin when only the `swift format` command is entered causes significant confusion for new users.
Although there were suggestions to provide a default behavior for convenience, I agree that it is not appropriate for a destructive change to take effect immediately.

However, at the very least, some guidance is needed to prevent the command from being perceived as hanging, so I've improved usability to output additional guidance when the user enters the `swift format` command alone.(same in `swift format lint`).

