### PR TITLE
[Perf][WhitespaceLinter] Use hand crafted "is whitespace" function

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
+++ b/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
@@ -339,9 +339,16 @@ public class WhitespaceLinter {
     startingAt offset: Int,
     in data: [UTF8.CodeUnit]
   ) -> ArraySlice<UTF8.CodeUnit> {
+    func isWhitespace(_ char: UTF8.CodeUnit) -> Bool {
+      switch char {
+      case UInt8(ascii: " "), UInt8(ascii: "\n"), UInt8(ascii: "\t"), UInt8(ascii: "\r"), /*VT*/ 0x0B, /*FF*/ 0x0C:
+        return true
+      default:
+        return false
+      }
+    }
     guard
-      let whitespaceEnd =
-        data[offset...].firstIndex(where: { !UnicodeScalar($0).properties.isWhitespace })
+      let whitespaceEnd = data[offset...].firstIndex(where: { !isWhitespace($0) })
     else {
       return data[offset..<data.endIndex]
     }


### PR DESCRIPTION
* `UnicodeScalar(_:)` on arbitrary UTF8 code point was wrong. It only works correctly if the code point is < 0x80
* `UnicodeScalar.Properties.isWhitespace` is slow. Profiling `lint` showed it was taking 13.6% of the entire run time
* Whitespaces in Unicode "Basic Latin" block are well defined, there's no need to consult `UnicodeScalar.Properties`

<img width="1019" alt="Screenshot 2025-01-13 at 10 25 12 AM" src="https://github.com/user-attachments/assets/387f0a2a-ad58-4e50-a505-b3e49f99619a" />

```
swift-format lint --recursive /tmp/swift-syntax-509.0.0`
// Before
Instructions executed: 54264413578
// After
Instructions executed: 49121489746
```