### PR TITLE
Modify PrettyPrinter to output diagnostics using shortened relative paths

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -819,7 +819,7 @@ public class PrettyPrinter {
     context.findingEmitter.emit(
       message,
       category: category,
-      location: Finding.Location(file: context.fileURL.path, line: outputBuffer.lineNumber, column: column)
+      location: Finding.Location(file: context.fileURL.relativePath, line: outputBuffer.lineNumber, column: column)
     )
   }
 }


### PR DESCRIPTION
Resolve #818 

Modified `PrettyPrinter`'s diagnostic logic to output diagnostics with shortened relative paths instead of full paths, as I believe this is more appropriate.