### PR TITLE
Improve the formatting logic of OmitExplicitReturns rule

### DIFF
--- a/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
+++ b/Sources/SwiftFormat/Rules/OmitExplicitReturns.swift
@@ -60,7 +60,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
     guard let accessorBlock = binding.accessorBlock,
       let transformed = transformAccessorBlock(accessorBlock)
     else {
-      return node
+      return super.visit(node)
     }
 
     binding.accessorBlock = transformed
@@ -145,7 +145,7 @@ public final class OmitExplicitReturns: SyntaxFormatRule {
     CodeBlockItemListSyntax([
       CodeBlockItemSyntax(
         leadingTrivia: returnStmt.leadingTrivia,
-        item: .expr(returnStmt.expression!),
+        item: .expr(returnStmt.expression!.detached.with(\.trailingTrivia, [])),
         semicolon: nil,
         trailingTrivia: returnStmt.trailingTrivia
       )

--- a/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OmitReturnsTests.swift
@@ -119,4 +119,46 @@ final class OmitReturnsTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testInVariableBindings() {
+    assertFormatting(
+      OmitExplicitReturns.self,
+      input: """
+          var f = l.filter { 1️⃣return $0.a != o }
+          var bar = l.filter { 
+            2️⃣return $0.a != o
+          }
+        """,
+      expected: """
+          var f = l.filter { $0.a != o }
+          var bar = l.filter { 
+            $0.a != o
+          }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression"),
+        FindingSpec("2️⃣", message: "'return' can be omitted because body consists of a single expression"),
+      ]
+    )
+  }
+
+  func testInVariableBindingWithTrailingTrivia() {
+    assertFormatting(
+      OmitExplicitReturns.self,
+      input: """
+          var f = l.filter { 
+            1️⃣return $0.a != o // comment
+          }
+        """,
+      expected: """
+          var f = l.filter { 
+            $0.a != o // comment
+          }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "'return' can be omitted because body consists of a single expression")
+      ]
+    )
+  }
+
 }


### PR DESCRIPTION
Resolve #812 and fix an additional minor bug that was discovered.
I will leave the explanation in the comments.