### PR TITLE
Ignore backticks in documentation abstracts

### DIFF
--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -97,8 +97,13 @@ public final class BeginDocumentationCommentWithOneLineSummary: SyntaxLintRule {
     else { return }
 
     // For the purposes of checking the sentence structure of the comment, we can operate on the
-    // plain text; we don't need any of the styling.
-    let trimmedText = briefSummary.plainText.trimmingCharacters(in: .whitespacesAndNewlines)
+    // plain text; we don't need any of the styling. Additionally, the backticks that are
+    // frequently used to denote symbol names cause issues with quote identification, and
+    // aren't necessary for this purpose.
+    let trimmedText = briefSummary.plainText
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "``.+?``", with: "ZZZ", options: .regularExpression)
+      .replacingOccurrences(of: "`.+?`", with: "zzz", options: .regularExpression)
     let (commentSentences, trailingText) = sentences(in: trimmedText)
     if commentSentences.count == 0 {
       diagnose(.terminateSentenceWithPeriod(trimmedText), on: decl)

--- a/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
+++ b/Sources/SwiftFormat/Rules/BeginDocumentationCommentWithOneLineSummary.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SwiftSyntax
 import Markdown
+import SwiftSyntax
 
 #if os(macOS)
 import NaturalLanguage

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -31,6 +31,13 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
         // ...
         }
 
+        /// Open a scope enclosed by `"typewriter"` double-quotes.
+        struct BeginTypewriterDoubleQuotes: MDocMacroProtocol {}
+
+        /// Before parsing arguments, capture all inputs that follow the `--`
+        /// terminator in this argument array.
+        public static var postTerminator: ArgumentArrayParsingStrategy
+
         /// This docline should not succeed.
         /// There are two sentences without a blank line between them.
         1️⃣struct Test {}

--- a/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
+++ b/Tests/SwiftFormatTests/Rules/BeginDocumentationCommentWithOneLineSummaryTests.swift
@@ -38,6 +38,10 @@ final class BeginDocumentationCommentWithOneLineSummaryTests: LintOrFormatRuleTe
         /// terminator in this argument array.
         public static var postTerminator: ArgumentArrayParsingStrategy
 
+        /// The source converter for the text in the current test, which
+        /// is related to ``thisInvalid(method.Signature:)``.
+        var converter: SourceLocationConverter!
+
         /// This docline should not succeed.
         /// There are two sentences without a blank line between them.
         1️⃣struct Test {}


### PR DESCRIPTION
The linguistic tagger doesn't do a great job recognizing backticks as opening vs. closing quotes, so some valid abstracts that contain backticks were being rejected by the `BeginDocumentationCommentWithOneLineSummary` rule. This change removes any `InlineCode` nodes from the abstract paragraph before processing, since they aren't important to that judgment.

Fixes #924.