### PR TITLE
Fix rejected assumeFilename when path argument is '-'

### DIFF
--- a/Sources/swift-format/Subcommands/LintFormatOptions.swift
+++ b/Sources/swift-format/Subcommands/LintFormatOptions.swift
@@ -107,7 +107,7 @@ struct LintFormatOptions: ParsableArguments {
       throw ValidationError("'--recursive' is only valid when formatting or linting files")
     }
 
-    if assumeFilename != nil && !paths.isEmpty {
+    if assumeFilename != nil && !(paths.isEmpty || paths == ["-"]) {
       throw ValidationError("'--assume-filename' is only valid when reading from stdin")
     }
 


### PR DESCRIPTION
This fixes a bug  where `swift-format` wouldn't execute when argument `--assume-filename` is used together with a path argument of `-` (which is suggested since https://github.com/swiftlang/swift-format/pull/914) when formatting from `stdin`.