### PR TITLE
Skip flaky performance test on Windows

### DIFF
--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @_spi(Testing) import _SwiftFormatTestSupport
 
 final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {
-  func testWhitespaceLinterPerformance() {
+  func testWhitespaceLinterPerformance() throws {
     #if os(Windows)
     // https://github.com/swiftlang/swift-format/issues/939
     throw XCTSkip("This test is flaky on Windows")

--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -7,8 +7,8 @@ import XCTest
 final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {
   func testWhitespaceLinterPerformance() {
     #if os(Windows)
-      // https://github.com/swiftlang/swift-format/issues/939
-      throw XCTSkip("This test is flaky on Windows")
+    // https://github.com/swiftlang/swift-format/issues/939
+    throw XCTSkip("This test is flaky on Windows")
     #endif
     let input = String(
       repeating: """

--- a/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
+++ b/Tests/SwiftFormatPerformanceTests/WhitespaceLinterPerformanceTests.swift
@@ -6,6 +6,10 @@ import XCTest
 
 final class WhitespaceLinterPerformanceTests: DiagnosingTestCase {
   func testWhitespaceLinterPerformance() {
+    #if os(Windows)
+      // https://github.com/swiftlang/swift-format/issues/939
+      throw XCTSkip("This test is flaky on Windows")
+    #endif
     let input = String(
       repeating: """
         import      SomeModule


### PR DESCRIPTION
Let's skip `testWhitespaceLinterPerformance` on Windows until someone with more linter performance insights can craft a real fix for https://github.com/swiftlang/swift-format/issues/939