### PR TITLE
Make the error message for an invalid version more user-friendly

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -21,6 +21,13 @@ import Foundation
 /// with the previous format.
 internal let highestSupportedConfigurationVersion = 1
 
+private struct ConfigurationDecodingError: LocalizedError {
+  var errorDescription: String?
+  init(errorDescription: String) {
+    self.errorDescription = errorDescription
+  }
+}
+
 /// Holds the complete set of configured values and defaults.
 public struct Configuration: Codable, Equatable {
 
@@ -285,11 +292,9 @@ public struct Configuration: Codable, Equatable {
     // If the version number is not present, assume it is 1.
     self.version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
     guard version <= highestSupportedConfigurationVersion else {
-      throw DecodingError.dataCorruptedError(
-        forKey: .version,
-        in: container,
-        debugDescription:
-          "This version of the formatter does not support configuration version \(version)."
+      throw ConfigurationDecodingError(
+        errorDescription:
+          "This version of the formatter does not support configuration version \(version). The highest supported version is \(highestSupportedConfigurationVersion)."
       )
     }
 


### PR DESCRIPTION
The error message displayed when an invalid version is entered in the `.swift-format` configuration is not user-friendly.
Currently, only version 1 exists, but in preparation for more versions being introduced in the future (such as #833..?), the message has been improved to help users easily identify and correct invalid version inputs.



This is the output after setting the version in the configuration file to `2`.
**before:**
  <img width="100%" alt="before" src="https://github.com/user-attachments/assets/9c618f2b-173d-40c4-8186-f5c589cad5a8" />
**after:**
  <img width="100%" alt="after" src="https://github.com/user-attachments/assets/be2ba438-1d4b-4b76-a6ef-5176a1875566" />
