### PR TITLE
Clean up symlink following and recursively follow symlink chains.

### DIFF
--- a/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
@@ -44,6 +44,16 @@ final class FileIteratorTests: XCTestCase {
     try touch("project/.build/generated.swift")
     try symlink("project/link.swift", to: "project/.hidden.swift")
     try symlink("project/rellink.swift", relativeTo: ".hidden.swift")
+
+    #if !(os(Windows) && compiler(<5.10))
+    // Test both a self-cycle and a cycle between multiple symlinks.
+    try symlink("project/cycliclink.swift", relativeTo: "cycliclink.swift")
+    try symlink("project/linktolink.swift", relativeTo: "link.swift")
+
+    // Test symlinks that use nonstandardized paths.
+    try symlink("project/2stepcyclebegin.swift", relativeTo: "../project/2stepcycleend.swift")
+    try symlink("project/2stepcycleend.swift", relativeTo: "./2stepcyclebegin.swift")
+    #endif
   }
 
   override func tearDownWithError() throws {
@@ -70,6 +80,36 @@ final class FileIteratorTests: XCTestCase {
     XCTAssertTrue(seen.contains { $0.path.hasSuffix("project/real2.swift") })
     // Hidden but found through the visible symlink project/link.swift
     XCTAssertTrue(seen.contains { $0.path.hasSuffix("project/.hidden.swift") })
+  }
+
+  func testFollowSymlinksToSymlinks() throws {
+    #if os(Windows) && compiler(<5.10)
+    try XCTSkipIf(true, "Foundation does not follow symlinks on Windows")
+    #endif
+    let seen = allFilesSeen(
+      iteratingOver: [tmpURL("project/linktolink.swift")],
+      followSymlinks: true
+    )
+    // Hidden but found through the visible symlink chain.
+    XCTAssertTrue(seen.contains { $0.path.hasSuffix("project/.hidden.swift") })
+  }
+
+  func testSymlinkCyclesAreIgnored() throws {
+    #if os(Windows) && compiler(<5.10)
+    try XCTSkipIf(true, "Foundation does not follow symlinks on Windows")
+    #endif
+    let seen = allFilesSeen(
+      iteratingOver: [
+        tmpURL("project/cycliclink.swift"),
+        tmpURL("project/2stepcyclebegin.swift"),
+        tmpURL("project/link.swift"),
+      ],
+      followSymlinks: true
+    )
+    // Hidden but found through the visible symlink chain.
+    XCTAssertTrue(seen.contains { $0.path.hasSuffix("project/.hidden.swift") })
+    // And the cycles were ignored.
+    XCTAssertEqual(seen.count, 1)
   }
 
   func testTraversesHiddenFilesIfExplicitlySpecified() throws {


### PR DESCRIPTION
This started out as a weird debugging journey. We had a team running `swift-format` as part of a Bazel action to format generated Swift code. The action basically just ran `swift-format $input > $output`. This action started failing (generating no output) in this environment because the Bazel action workspace was set up such that `$input` was a symlink to the actual file. Even if I updated the action to pass `--follow-symlinks`, the old `FileIterator` code had a `fallthrough` that didn't correctly handle the case where a path passed directly on the command line was a symlink to a *file* instead of a directory.

The reason that this _actually_ started failing was because we finally updated our internal toolchain to use the new swift-foundation instead of the legacy swift-corelibs-foundation (before it was layered on top of swift-foundation). Something in the implementation of `FileManager` changed subtly and started giving us `URL`s back that pointed to symlinks when previously we were getting them pre-resolved, which revealed the above issue.

While I was in here, I decided to add support for following symlinks to other symlinks, just to make sure that didn't become an issue in the future.