### PR TITLE
Support file-level ignore directive for specific rules

### DIFF
--- a/Documentation/IgnoringSource.md
+++ b/Documentation/IgnoringSource.md
@@ -77,6 +77,22 @@ var a = foo+bar+baz
 These ignore comments also apply to all children of the node, identical to the
 behavior of the formatting ignore directive described above.
 
+You can also disable specific source transforming rules for an entire file
+by using the file-level ignore directive with a list of rule names. For example:
+
+```swift
+// swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+import Zoo
+import Arrays
+
+struct Foo {
+  func foo() { bar();baz(); }
+}
+```
+In this case, only the DoNotUseSemicolons and FullyIndirectEnum rules are disabled
+throughout the file, while all other formatting rules (such as line breaking and 
+indentation) remain active.
+
 ## Understanding Nodes
 
 `swift-format` parses Swift into an abstract syntax tree, where each element of

--- a/Sources/SwiftFormat/Rules/OrderedImports.swift
+++ b/Sources/SwiftFormat/Rules/OrderedImports.swift
@@ -86,7 +86,15 @@ public final class OrderedImports: SyntaxFormatRule {
       if atStartOfFile {
         switch line.type {
         case .comment:
-          commentBuffer.append(line)
+          if line.description.contains(IgnoreDirective.file.description) {
+            // If the file-level ignore directive is included in the comments of the import statements,
+            // consider the comments before the file-level ignore directive as part of the fileHeader.
+            fileHeader.append(contentsOf: commentBuffer)
+            fileHeader.append(line)
+            commentBuffer = []
+          } else {
+            commentBuffer.append(line)
+          }
           continue
 
         case .blankLine:
@@ -520,8 +528,8 @@ fileprivate class Line {
   }
 }
 
-extension Line: CustomDebugStringConvertible {
-  var debugDescription: String {
+extension Line: CustomStringConvertible {
+  var description: String {
     var description = ""
     if !leadingTrivia.isEmpty {
       var newlinesCount = 0

--- a/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/OrderedImportsTests.swift
@@ -651,4 +651,126 @@ final class OrderedImportsTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testFileIgnoreDirectiveOnly() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+        import Zoo
+        1️⃣import Arrays
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      expected: """
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+
+        import Arrays
+        import Zoo
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+  }
+
+  func testFileIgnoreDirectiveWithAlreadySortedImports() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+        import Arrays
+        import Zoo
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      expected: """
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+
+        import Arrays
+        import Zoo
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """
+    )
+  }
+
+  func testFileIgnoreDirectiveWithOtherComments() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        // We need to ignore this file because it is generated
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+        // Line comment for Zoo
+        import Zoo
+        // Line comment for Array
+        1️⃣import Arrays
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      expected: """
+        // We need to ignore this file because it is generated
+        // swift-format-ignore-file: DoNotUseSemicolons, FullyIndirectEnum
+
+        // Line comment for Array
+        import Arrays
+        // Line comment for Zoo
+        import Zoo
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+  }
+
+  func testFileHeaderContainsFileIgnoreDirective() {
+    assertFormatting(
+      OrderedImports.self,
+      input: """
+        // This file has important contents.
+        // swift-format-ignore-file: DoNotUseSemicolons
+        // swift-format-ignore-file: FullyIndirectEnum
+        // Everything in this file is ignored.
+
+        import Zoo
+        1️⃣import Arrays
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      expected: """
+        // This file has important contents.
+        // swift-format-ignore-file: DoNotUseSemicolons
+        // swift-format-ignore-file: FullyIndirectEnum
+        // Everything in this file is ignored.
+
+        import Arrays
+        import Zoo
+
+        struct Foo {
+          func foo() { bar();baz(); }
+        }
+        """,
+      findings: [
+        FindingSpec("1️⃣", message: "sort import statements lexicographically")
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Resolve #927

I have modified the function that disables specific rules in node-level directive so that it can also be reused for file-level directive, ensuring both follow the same logic.

Previously, if a file-level directive appeared in the topmost comment, we would always skip visiting nodes. However, with this change, we now visit child nodes when only specific rules are disabled. As a result, this caused an unintended side effect in cases where the `OrderedImports` rule was enabled. Specifically, a directive included in the `leadingTrivia` of a sorted import statement was being reordered along with the imports.
To resolve this, I modified the `OrderedImports` rule to treat the `swift-format-ignore-file` directive as part of the file header.

Additionally, to avoid simple string comparisons like:

```swift
if line.description.contains("swift-format-ignore-file") {
```

I have created an `IgnoreDirective` enum to handle ignore directives more cleanly.

For easier review, I have split the commits.
Once the review is complete, I will squash and force push them before merging. 🙂

