### PR TITLE
Run Windows tests inside a Docker container

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,8 +8,6 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    with:
-      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
Looks like GitHub updated Visual Studio on their Windows runners and the new SDK causes compilation issues. Run in a Docker container so we fully control the version of Visual Studio installed.