### PR TITLE
Run the publish release workflow inside a Docker container on Windows

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -99,7 +99,6 @@ jobs:
       matrix:
         release: [true, false]
     with:
-      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
       linux_pre_build_command: |
         git config --global --add safe.directory "$(realpath .)"
         git config --local user.name 'swift-ci'


### PR DESCRIPTION
Same reason as https://github.com/swiftlang/swift-format/pull/951.