### PR TITLE
[6.1] Run Windows tests inside a Docker container

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -99,7 +99,6 @@ jobs:
       matrix:
         release: [true, false]
     with:
-      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
       linux_pre_build_command: |
         git config --global --add safe.directory "$(realpath .)"
         git config --local user.name 'swift-ci'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,8 +8,6 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    with:
-      enable_windows_docker: false  # Dockerless Windows is 5-10 minutes faster than Docker on Windows
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
- **Explanation**: Looks like GitHub updated Visual Studio on their Windows runners and the new SDK causes compilation issues. Run in a Docker container so we fully control the version of Visual Studio installed.
- **Scope**: GitHub Actions used for PR testing and tagging swift-format semantic versioning releases
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift-format/pull/951 / https://github.com/swiftlang/swift-format/pull/952
- **Risk**: None, only affects CI, which is currently broken
- **Testing**: Checked that CI passes with this change on main
- **Reviewer**: @bnbarham 