### PR TITLE
Make the creation of a prerelease on GitHub a separate job in the publish release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -139,14 +139,21 @@ jobs:
         run: |
           git tag "${{ needs.create_release_commits.outputs.swift_format_version }}"
           git push origin "${{ needs.create_release_commits.outputs.swift_format_version }}"
+  create_prerelease:
+    name: Create prerelease on GitHub
+    runs-on: ubuntu-latest
+    needs: [create_release_commits, create_tag]
+    # Only create a release automatically for prereleases. For real releases, release notes should be crafted by hand.
+    if: ${{ github.event.inputs.prerelease }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${{ github.event.inputs.prerelease }}" != "true" ]]; then
-            # Only create a release automatically for prereleases. For real releases, release notes should be crafted by hand.
-            exit
-          fi
           gh release create "${{ needs.create_release_commits.outputs.swift_format_version }}" \
             --title "${{ needs.create_release_commits.outputs.swift_format_version }}" \
             --prerelease


### PR DESCRIPTION
This way the creation of the prerelease shows up as a separate box in the job’s execution pipeline, which is nicer.