### PR TITLE
Increase swift-tools-version to 5.9

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,8 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      linux_exclude_swift_versions: "[{\"swift_version\": \"5.8\"}]"
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version: 5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project


### PR DESCRIPTION
Dropping support to build the latest swift-format using a Swift 5.8 compiler to match https://github.com/swiftlang/swift-syntax/pull/3017.