### PR TITLE
Unify whitespace handling in linter and formatter

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/Comment.swift
+++ b/Sources/SwiftFormat/PrettyPrint/Comment.swift
@@ -21,13 +21,27 @@ extension StringProtocol {
   /// - Returns: The string with trailing whitespace removed.
   func trimmingTrailingWhitespace() -> String {
     if isEmpty { return String() }
-    let scalars = unicodeScalars
-    var idx = scalars.index(before: scalars.endIndex)
-    while scalars[idx].properties.isWhitespace {
-      if idx == scalars.startIndex { return String() }
-      idx = scalars.index(before: idx)
+    let utf8Array = Array(utf8)
+    var idx = utf8Array.endIndex - 1
+    while utf8Array[idx].isWhitespace {
+      if idx == utf8Array.startIndex { return String() }
+      idx -= 1
     }
-    return String(String.UnicodeScalarView(scalars[...idx]))
+    return String(decoding: utf8Array[...idx], as: UTF8.self)
+  }
+}
+
+extension UTF8.CodeUnit {
+  /// Checks if the UTF-8 code unit represents a whitespace character.
+  ///
+  /// - Returns: `true` if the code unit represents a whitespace character, otherwise `false`.
+  var isWhitespace: Bool {
+    switch self {
+    case UInt8(ascii: " "), UInt8(ascii: "\n"), UInt8(ascii: "\t"), UInt8(ascii: "\r"), /*VT*/ 0x0B, /*FF*/ 0x0C:
+      return true
+    default:
+      return false
+    }
   }
 }
 

--- a/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
+++ b/Sources/SwiftFormat/PrettyPrint/WhitespaceLinter.swift
@@ -339,16 +339,8 @@ public class WhitespaceLinter {
     startingAt offset: Int,
     in data: [UTF8.CodeUnit]
   ) -> ArraySlice<UTF8.CodeUnit> {
-    func isWhitespace(_ char: UTF8.CodeUnit) -> Bool {
-      switch char {
-      case UInt8(ascii: " "), UInt8(ascii: "\n"), UInt8(ascii: "\t"), UInt8(ascii: "\r"), /*VT*/ 0x0B, /*FF*/ 0x0C:
-        return true
-      default:
-        return false
-      }
-    }
     guard
-      let whitespaceEnd = data[offset...].firstIndex(where: { !isWhitespace($0) })
+      let whitespaceEnd = data[offset...].firstIndex(where: { !$0.isWhitespace })
     else {
       return data[offset..<data.endIndex]
     }

--- a/Tests/SwiftFormatTests/PrettyPrint/CommentTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/CommentTests.swift
@@ -1094,4 +1094,17 @@ final class CommentTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: input, linelength: 80)
   }
+
+  func testUnexpectedUnicodeCharacters() {
+    let input =
+      """
+      // Hello World\u{2028}
+      // Hello\u{20}\u{2028}World
+      // Hello World\u{2028}\u{2029}\u{2029}
+      // Hello World\u{20}\u{20}\u{20}\u{2028}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: input, linelength: 80)
+  }
 }

--- a/Tests/SwiftFormatTests/PrettyPrint/WhitespaceLintTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/WhitespaceLintTests.swift
@@ -255,4 +255,29 @@ final class WhitespaceLintTests: WhitespaceTestCase {
       ]
     )
   }
+
+  func testUnexpectedUnicodeCharacters() {
+    assertWhitespaceLint(
+      input: """
+        // Hello World\u{2028}
+        // Hello\u{20}\u{2028}World
+        // Hello World\u{2028}\u{2029}\u{2029}
+        // Hello World              \u{2028}
+        // Hello World\u{2028}1️⃣\u{20}\u{20}\u{20}
+
+        """,
+      expected: """
+        // Hello World\u{2028}
+        // Hello\u{20}\u{2028}World
+        // Hello World\u{2028}\u{2029}\u{2029}
+        // Hello World              \u{2028}
+        // Hello World\u{2028}
+
+        """,
+      linelength: 30,
+      findings: [
+        FindingSpec("1️⃣", message: "remove trailing whitespace")
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Resolve #960 

In Xcode, using certain unicode characters (such as `U+2028`) in code causes errors. Following the same logic, I modified the linter so that it no longer treats these characters as valid and instead emits a message prompting their removal. Comments containing these characters will also no longer cause crashes when lint.

To ensure scalability, I introduced a `UnicodeException` enum that maintains a collection of unprocessable unicode characters. When adding a new unexpected unicode character in the future, simply defining a new case and its corresponding `utf8Bytes` will allow it to be properly handled as an unexpected unicode character.