### PR TITLE
Update for swift-syntax AttributeSyntax.Arguments changes

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1880,11 +1880,6 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
-  override func visit(_ node: ExposeAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
-    after(node.comma, tokens: .break(.same, size: 1))
-    return .visitChildren
-  }
-
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
 


### PR DESCRIPTION
Some specialized `AttributeSyntax.Arguments` cases and related types are being removed from swift-syntax.