### PR TITLE
Add concurrency control to cancel in-progress PR workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Test


### PR DESCRIPTION
When updating a pull request that's already open, each new commit can trigger a workflow. If the PR author doesn't have permission to cancel workflows, this can lead to unnecessary executions.
To avoid redundant executions and reduce resource usage, this change cancels any in-progress workflow for the same pull request when a new one is triggered by a commit push, ensuring only one active workflow per PR.