### PR TITLE
Fix type mismatch error in `reflowMultilineStringLiterals`

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -204,7 +204,30 @@ switch someValue {
 ---
 
 ### `reflowMultilineStringLiterals`
-**type:** `string`
+
+> [!NOTE]
+> This setting should be specified as a string value (e.g. "never")
+> For backward compatibility with swift-format version 601.0.0, the configuration also accepts the legacy object format where the setting is specified as an object with a single key (e.g., ⁠{ "never": {} }).
+
+**type:** `string` or `object` (legacy)
+
+**example:**
+
+For all versions above 601.0.0, the configuration should be specified as a string, for example:
+```json
+{
+  "reflowMultilineStringLiterals": "never"
+}
+```
+
+For version 601.0.0, the configuration should be specified as an object, for example:
+```json
+{
+  "reflowMultilineStringLiterals": {
+    "never": {}
+  }
+}
+```
 
 **description:** Determines how multiline string literals should reflow when formatted.
 

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -206,8 +206,8 @@ switch someValue {
 ### `reflowMultilineStringLiterals`
 
 > [!NOTE]
-> This setting should be specified as a string value (e.g. "never")
-> For backward compatibility with swift-format version 601.0.0, the configuration also accepts the legacy object format where the setting is specified as an object with a single key (e.g., ⁠{ "never": {} }).
+> This setting should be specified as a string value (e.g. `"never"`)
+> For backward compatibility with swift-format version 601.0.0, the configuration also accepts the legacy object format where the setting is specified as an object with a single key (e.g., ⁠`{ "never": {} }`).
 
 **type:** `string` or `object` (legacy)
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -265,14 +265,6 @@ public struct Configuration: Codable, Equatable {
     case onlyLinesOverLength
     case always
 
-    var isNever: Bool {
-      self == .never
-    }
-
-    var isAlways: Bool {
-      self == .always
-    }
-
     /// Converts this legacy enum to the corresponding `MultilineStringReflowBehavior` value.
     func toMultilineStringReflowBehavior() -> MultilineStringReflowBehavior {
       switch self {

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -259,6 +259,53 @@ public struct Configuration: Codable, Equatable {
     }
   }
 
+  /// A private enum created to maintain backward compatibility with swift-format version 601.0.0,
+  /// which had a `MultilineStringReflowBehavior` enum without a String raw type.
+  ///
+  /// In version 601.0.0, the `reflowMultilineStringLiterals` configuration was encoded as an object
+  /// with a single key (e.g., `{ "never": {} }`) rather than as a string (e.g., `"never"`). This
+  /// enum allows decoding from both formats:
+  /// - First, we attempt to decode as a String using `MultilineStringReflowBehavior`
+  /// - If that fails, we fall back to this legacy format
+  /// - If both attempts fail, an error will be thrown
+  ///
+  /// This approach preserves compatibility without requiring a configuration version bump.
+  private enum LegacyMultilineStringReflowBehavior: Codable {
+    case never
+    case onlyLinesOverLength
+    case always
+
+    var isNever: Bool {
+      switch self {
+      case .never:
+        return true
+      default:
+        return false
+      }
+    }
+
+    var isAlways: Bool {
+      switch self {
+      case .always:
+        return true
+      default:
+        return false
+      }
+    }
+
+    /// Converts this legacy enum to the corresponding `MultilineStringReflowBehavior` value.
+    func toMultilineStringReflowBehavior() -> MultilineStringReflowBehavior {
+      switch self {
+      case .never:
+        return .never
+      case .always:
+        return .always
+      case .onlyLinesOverLength:
+        return .onlyLinesOverLength
+      }
+    }
+  }
+
   public var reflowMultilineStringLiterals: MultilineStringReflowBehavior
 
   /// Determines whether to add indentation whitespace to blank lines or remove it entirely.
@@ -371,9 +418,31 @@ public struct Configuration: Codable, Equatable {
       )
       ?? defaults.multiElementCollectionTrailingCommas
 
-    self.reflowMultilineStringLiterals =
-      try container.decodeIfPresent(MultilineStringReflowBehavior.self, forKey: .reflowMultilineStringLiterals)
-      ?? defaults.reflowMultilineStringLiterals
+    self.reflowMultilineStringLiterals = try {
+      // Try to decode `reflowMultilineStringLiterals` as a string
+      // This handles configurations using the String raw value format (e.g. "never").
+      // If an error occurs, we'll silently bypass it and fall back to the legacy behavior.
+      if let behavior = try? container.decodeIfPresent(
+        MultilineStringReflowBehavior.self,
+        forKey: .reflowMultilineStringLiterals
+      ) {
+        return behavior
+      }
+
+      // If the modern format fails, try to decode as an object with a single key.
+      // This handles configurations from swift-format v601.0.0 (e.g. { "never": {} }).
+      // If an error occurs in this step, we'll propagate it to the caller.
+      if let legacyBehavior = try container.decodeIfPresent(
+        LegacyMultilineStringReflowBehavior.self,
+        forKey: .reflowMultilineStringLiterals
+      ) {
+        return legacyBehavior.toMultilineStringReflowBehavior()
+      }
+
+      // If the key is not present in the configuration at all, use the default value.
+      return defaults.reflowMultilineStringLiterals
+    }()
+
     self.indentBlankLines =
       try container.decodeIfPresent(
         Bool.self,

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -197,7 +197,7 @@ public struct Configuration: Codable, Equatable {
   public var multiElementCollectionTrailingCommas: Bool
 
   /// Determines how multiline string literals should reflow when formatted.
-  public enum MultilineStringReflowBehavior: Codable {
+  public enum MultilineStringReflowBehavior: String, Codable {
     /// Never reflow multiline string literals.
     case never
     /// Reflow lines in string literal that exceed the maximum line length. For example with a line length of 10:

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -241,21 +241,11 @@ public struct Configuration: Codable, Equatable {
     case always
 
     var isNever: Bool {
-      switch self {
-      case .never:
-        return true
-      default:
-        return false
-      }
+      self == .never
     }
 
     var isAlways: Bool {
-      switch self {
-      case .always:
-        return true
-      default:
-        return false
-      }
+      self == .always
     }
   }
 
@@ -276,32 +266,19 @@ public struct Configuration: Codable, Equatable {
     case always
 
     var isNever: Bool {
-      switch self {
-      case .never:
-        return true
-      default:
-        return false
-      }
+      self == .never
     }
 
     var isAlways: Bool {
-      switch self {
-      case .always:
-        return true
-      default:
-        return false
-      }
+      self == .always
     }
 
     /// Converts this legacy enum to the corresponding `MultilineStringReflowBehavior` value.
     func toMultilineStringReflowBehavior() -> MultilineStringReflowBehavior {
       switch self {
-      case .never:
-        return .never
-      case .always:
-        return .always
-      case .onlyLinesOverLength:
-        return .onlyLinesOverLength
+      case .never: .never
+      case .always: .always
+      case .onlyLinesOverLength: .onlyLinesOverLength
       }
     }
   }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -64,4 +64,47 @@ final class ConfigurationTests: XCTestCase {
     let path = #"\\mount\test.swift"#
     XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
   }
+
+  func testDecodingReflowMultilineStringLiteralsAsString() throws {
+    typealias MultilineStringReflowBehavior = Configuration.MultilineStringReflowBehavior
+
+    let testCases = [
+      "never": MultilineStringReflowBehavior.never,
+      "always": MultilineStringReflowBehavior.always,
+      "onlyLinesOverLength": MultilineStringReflowBehavior.onlyLinesOverLength,
+    ]
+
+    for (jsonString, expectedBehavior) in testCases {
+      let jsonData = """
+        {
+            "reflowMultilineStringLiterals": "\(jsonString)"
+        }
+        """.data(using: .utf8)!
+
+      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
+    }
+  }
+
+  func testDecodingReflowMultilineStringLiteralsAsObject() throws {
+    typealias MultilineStringReflowBehavior = Configuration.MultilineStringReflowBehavior
+
+    let testCases = [
+      "{ \"never\": {} }": MultilineStringReflowBehavior.never,
+      "{ \"always\": {} }": MultilineStringReflowBehavior.always,
+      "{ \"onlyLinesOverLength\": {} }": MultilineStringReflowBehavior.onlyLinesOverLength,
+    ]
+
+    for (jsonString, expectedBehavior) in testCases {
+      let jsonData = """
+        {
+            "reflowMultilineStringLiterals": \(jsonString)
+        }
+        """.data(using: .utf8)!
+
+      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
+    }
+  }
+
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -66,12 +66,10 @@ final class ConfigurationTests: XCTestCase {
   }
 
   func testDecodingReflowMultilineStringLiteralsAsString() throws {
-    typealias MultilineStringReflowBehavior = Configuration.MultilineStringReflowBehavior
-
-    let testCases = [
-      "never": MultilineStringReflowBehavior.never,
-      "always": MultilineStringReflowBehavior.always,
-      "onlyLinesOverLength": MultilineStringReflowBehavior.onlyLinesOverLength,
+    let testCases: [String: Configuration.MultilineStringReflowBehavior] = [
+      "never": .never,
+      "always": .always,
+      "onlyLinesOverLength": .onlyLinesOverLength,
     ]
 
     for (jsonString, expectedBehavior) in testCases {
@@ -87,12 +85,11 @@ final class ConfigurationTests: XCTestCase {
   }
 
   func testDecodingReflowMultilineStringLiteralsAsObject() throws {
-    typealias MultilineStringReflowBehavior = Configuration.MultilineStringReflowBehavior
 
-    let testCases = [
-      "{ \"never\": {} }": MultilineStringReflowBehavior.never,
-      "{ \"always\": {} }": MultilineStringReflowBehavior.always,
-      "{ \"onlyLinesOverLength\": {} }": MultilineStringReflowBehavior.onlyLinesOverLength,
+    let testCases: [String: Configuration.MultilineStringReflowBehavior] = [
+      "{ \"never\": {} }": .never,
+      "{ \"always\": {} }": .always,
+      "{ \"onlyLinesOverLength\": {} }": .onlyLinesOverLength,
     ]
 
     for (jsonString, expectedBehavior) in testCases {

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -14,3 +14,7 @@ API breakage: var Finding.severity has been removed
 API breakage: var FindingCategorizing.defaultSeverity has been removed
 API breakage: var FindingCategorizing.defaultSeverity has been removed
 API breakage: func Rule.diagnose(_:on:severity:anchor:notes:) has been renamed to func diagnose(_:on:anchor:notes:)
+API breakage: func Configuration.MultilineStringReflowBehavior.hash(into:) has been removed
+API breakage: func Configuration.MultilineStringReflowBehavior.encode(to:) has been removed
+API breakage: var Configuration.MultilineStringReflowBehavior.hashValue has been removed
+API breakage: constructor Configuration.MultilineStringReflowBehavior.init(from:) has been removed


### PR DESCRIPTION
### Problem description

- Environment: swift-format with v601.0.0 or build-in support with Xcode 16.3
- Issue:
When running `swift-format <path>` command with a custom configuration that contains `reflowMultilineStringLiterals` will receive the below error

  ```
  <unknown>: error: Unable to read configuration for <path-to-file>: The data couldn’t be read because it isn’t in the correct format.
  ```
- How to reproduce:
  1. Create a `.swift-format` config file in any project with swift-format setup
  2. Make sure the config file contains the setting of `reflowMultilineStringLiterals` based on the document.
  3. Run the `swift-format <path>` command and the error should show in the console

### Root cause

The `MultilineStringReflowBehavior` enum in `/Sources/SwiftFormat/API/Configuration.swift` is used to parse the value of `reflowMultilineStringLiterals` from the config file, however, the origin enum raw type is missing which causes the `decodeIfPresent(_:forKey:)` function throws an `DecodingError.typeMismatch` error when decoding.

The root cause can be verified by running the `swift-format dump-configuration` command. The console shows that the default value of key `reflowMultilineStringLiterals` is structured as:
```json
"reflowMultilineStringLiterals" : {
  "never" : {

  }
},
```
but according to the documentation, the value of ⁠reflowMultilineStringLiterals should be a string like:
```json
"reflowMultilineStringLiterals": "never",
```

### Solution

By adding a raw type `String` to the enum `MultilineStringReflowBehavior`:
```swift
// Before
enum MultilineStringReflowBehavior: Codable { ... }

// After
enum MultilineStringReflowBehavior: String, Codable { ... }

```
This solves the current issue and makes the config file align with what is defined in the documentation.

```json
{
  "fileScopedDeclarationPrivacy" : {
    "accessLevel" : "private"
  },
  "indentConditionalCompilationBlocks" : true,
  "indentSwitchCaseLabels" : false,
  "indentation" : {
    "spaces" : 2
  },
  "lineBreakAroundMultilineExpressionChainComponents" : false,
  "lineBreakBeforeControlFlowKeywords" : false,
  "lineBreakBeforeEachArgument" : false,
  "lineBreakBeforeEachGenericRequirement" : false,
  "lineBreakBetweenDeclarationAttributes" : false,
  "lineLength" : 100,
  "maximumBlankLines" : 1,
  "multiElementCollectionTrailingCommas" : true,
  "noAssignmentInExpressions" : {
    "allowedFunctions" : [
      "XCTAssertNoThrow"
    ]
  },
  "prioritizeKeepingFunctionOutputTogether" : false,

  "reflowMultilineStringLiterals" : "never",

  "respectsExistingLineBreaks" : true,
  "rules" : { "...ignored with unchanged" }
  "spacesAroundRangeFormationOperators" : false,
  "spacesBeforeEndOfLineComments" : 2,
  "tabWidth" : 8,
  "version" : 1
}
```