### PR TITLE
Change default release version for GitHub action releases to 603.0.0

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,13 +11,13 @@ on:
         required: true
       swift_format_version:
         type: string
-        default: 601.0.0
+        default: 603.0.0
         description: "swift-format version"
         # The version of swift-format to tag. If this is a prerelease, `-prerelease-<date>` is added to this version.
         required: true
       swift_syntax_tag:
         type: string
-        default: 601.0.0
+        default: 603.0.0
         description: "swift-syntax version"
         # The swift-syntax version to depend on. If this is a prerelease, the latest swift-syntax prerelease tag for this version is used.
         required: true


### PR DESCRIPTION
We don’t release any prereleases from main (we only do for release branches) but this makes us ready for the 6.3 branch when it comes up.