### PR TITLE
Merge `main` into `release/6.2`

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,53 @@
+name: Create PR to merge main into release branch
+
+# In the first period after branching the release branch, we typically want to include all changes from `main` also in the release branch. This workflow automatically creates a PR every Monday to merge main into the release branch.
+# Later in the release cycle we should stop this practice to avoid landing risky changes by disabling this workflow. To do so, disable the workflow as described in https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow
+
+on:
+  schedule:
+    - cron: '0 0 * * MON'
+  workflow_dispatch:
+
+jobs:
+  create_merge_pr:
+    name: Create PR to merge main into release branch
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'swiftlang/swift-format') || (github.event_name != 'schedule')  # Ensure that we don't run this on a schedule in a fork
+    steps:
+      - name: Set up variables
+        id: variables
+        run: |
+          echo "release_branch=release/6.2" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=automerge/merge-main-$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create merge commit
+        id: create_merge_commit
+        run: |
+          # Without this, we can't perform git operations in GitHub actions.
+          git config --global --add safe.directory "$(realpath .)"
+          git config --local user.name 'swift-ci'
+          git config --local user.email 'swift-ci@users.noreply.github.com'
+
+          git checkout ${{ steps.variables.outputs.release_branch }}
+          git merge main
+
+          if [[ "$(git rev-parse HEAD)" = "$(git rev-parse main)" ]]; then
+            echo "has_merged_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_merged_commits=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Push branch and create PR
+        id: push_branch
+        if: ${{ steps.create_merge_commit.outputs.has_merged_commits }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git checkout -b "${{ steps.variables.outputs.pr_branch }}"
+          git push --set-upstream origin "${{ steps.variables.outputs.pr_branch }}"
+
+          gh pr create -B "${{ steps.variables.outputs.release_branch }}" -H "${{ steps.variables.outputs.pr_branch }}" \
+            --title 'Merge `main` into `${{ steps.variables.outputs.release_branch }}`' \
+            --body 'This PR was automatically opened by a GitHub action. Review the changes included in this PR and determine if they should be included in the release branch. If yes, merge the PR. Otherwise revert changes that should not be included on this branch.'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Test

--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -204,7 +204,30 @@ switch someValue {
 ---
 
 ### `reflowMultilineStringLiterals`
-**type:** `string`
+
+> [!NOTE]
+> This setting should be specified as a string value (e.g. `"never"`)
+> For backward compatibility with swift-format version 601.0.0, the configuration also accepts the legacy object format where the setting is specified as an object with a single key (e.g., ⁠`{ "never": {} }`).
+
+**type:** `string` or `object` (legacy)
+
+**example:**
+
+For all versions above 601.0.0, the configuration should be specified as a string, for example:
+```json
+{
+  "reflowMultilineStringLiterals": "never"
+}
+```
+
+For version 601.0.0, the configuration should be specified as an object, for example:
+```json
+{
+  "reflowMultilineStringLiterals": {
+    "never": {}
+  }
+}
+```
 
 **description:** Determines how multiline string literals should reflow when formatted.
 

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -64,4 +64,44 @@ final class ConfigurationTests: XCTestCase {
     let path = #"\\mount\test.swift"#
     XCTAssertNil(Configuration.url(forConfigurationFileApplyingTo: URL(fileURLWithPath: path)))
   }
+
+  func testDecodingReflowMultilineStringLiteralsAsString() throws {
+    let testCases: [String: Configuration.MultilineStringReflowBehavior] = [
+      "never": .never,
+      "always": .always,
+      "onlyLinesOverLength": .onlyLinesOverLength,
+    ]
+
+    for (jsonString, expectedBehavior) in testCases {
+      let jsonData = """
+        {
+            "reflowMultilineStringLiterals": "\(jsonString)"
+        }
+        """.data(using: .utf8)!
+
+      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
+    }
+  }
+
+  func testDecodingReflowMultilineStringLiteralsAsObject() throws {
+
+    let testCases: [String: Configuration.MultilineStringReflowBehavior] = [
+      "{ \"never\": {} }": .never,
+      "{ \"always\": {} }": .always,
+      "{ \"onlyLinesOverLength\": {} }": .onlyLinesOverLength,
+    ]
+
+    for (jsonString, expectedBehavior) in testCases {
+      let jsonData = """
+        {
+            "reflowMultilineStringLiterals": \(jsonString)
+        }
+        """.data(using: .utf8)!
+
+      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
+    }
+  }
+
 }

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -14,3 +14,7 @@ API breakage: var Finding.severity has been removed
 API breakage: var FindingCategorizing.defaultSeverity has been removed
 API breakage: var FindingCategorizing.defaultSeverity has been removed
 API breakage: func Rule.diagnose(_:on:severity:anchor:notes:) has been renamed to func diagnose(_:on:anchor:notes:)
+API breakage: func Configuration.MultilineStringReflowBehavior.hash(into:) has been removed
+API breakage: func Configuration.MultilineStringReflowBehavior.encode(to:) has been removed
+API breakage: var Configuration.MultilineStringReflowBehavior.hashValue has been removed
+API breakage: constructor Configuration.MultilineStringReflowBehavior.init(from:) has been removed


### PR DESCRIPTION
Need to do this manually instead of through the GitHub action added by https://github.com/swiftlang/swift-format/pull/986 because there was a merge conflict because we changed the default version in `publish_release.yml` both on `main` and `release/6.2`.