### PR TITLE
Make linter emit warnings instead of errors by default

### DIFF
--- a/Sources/swift-format/Frontend/Frontend.swift
+++ b/Sources/swift-format/Frontend/Frontend.swift
@@ -200,14 +200,21 @@ class Frontend {
   /// Creates a new frontend with the given options.
   ///
   /// - Parameter lintFormatOptions: Options that apply during formatting or linting.
-  init(configurationOptions: ConfigurationOptions, lintFormatOptions: LintFormatOptions) {
+  init(
+    configurationOptions: ConfigurationOptions,
+    lintFormatOptions: LintFormatOptions,
+    treatWarningsAsErrors: Bool = false
+  ) {
     self.configurationOptions = configurationOptions
     self.lintFormatOptions = lintFormatOptions
 
     self.diagnosticPrinter = StderrDiagnosticPrinter(
       colorMode: lintFormatOptions.colorDiagnostics.map { $0 ? .on : .off } ?? .auto
     )
-    self.diagnosticsEngine = DiagnosticsEngine(diagnosticsHandlers: [diagnosticPrinter.printDiagnostic])
+    self.diagnosticsEngine = DiagnosticsEngine(
+      diagnosticsHandlers: [diagnosticPrinter.printDiagnostic],
+      treatWarningsAsErrors: treatWarningsAsErrors
+    )
     self.configurationProvider = ConfigurationProvider(diagnosticsEngine: self.diagnosticsEngine)
   }
 

--- a/Sources/swift-format/Subcommands/Lint.swift
+++ b/Sources/swift-format/Subcommands/Lint.swift
@@ -28,7 +28,7 @@ extension SwiftFormatCommand {
 
     @Flag(
       name: .shortAndLong,
-      help: "Fail on warnings. Deprecated: All findings are treated as errors now."
+      help: "Treat all findings as errors instead of warnings."
     )
     var strict: Bool = false
 
@@ -37,15 +37,11 @@ extension SwiftFormatCommand {
 
     func run() throws {
       try performanceMeasurementOptions.printingInstructionCountIfRequested {
-        let frontend = LintFrontend(configurationOptions: configurationOptions, lintFormatOptions: lintOptions)
-
-        if strict {
-          frontend.diagnosticsEngine.emitWarning(
-            """
-            Running swift-format with --strict is deprecated and will be removed in the future.
-            """
-          )
-        }
+        let frontend = LintFrontend(
+          configurationOptions: configurationOptions,
+          lintFormatOptions: lintOptions,
+          treatWarningsAsErrors: strict
+        )
         frontend.run()
 
         if frontend.diagnosticsEngine.hasErrors {


### PR DESCRIPTION
When running `swift-format lint` in an Xcode run script phase and it exits with a non-zero exit code, the build will fail. This started happening since we treated all linter findings as errors in https://github.com/swiftlang/swift-format/pull/943.

To fix this:
- Diagnose all findings as warnings again and exit with code 0 even if there are findings
- Resurrect `--strict` to treat all findings as errors and exit with 1 if there were any findings.

rdar://148389716