### PR TITLE
Allow comments in `.swift-format`

### DIFF
--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -293,7 +293,9 @@ public struct Configuration: Codable, Equatable {
   /// Creates a new `Configuration` by decoding it from the UTF-8 representation in the given data.
   public init(data: Data) throws {
     let jsonDecoder = JSONDecoder()
+    #if compiler(>=6)
     jsonDecoder.allowsJSON5 = true
+    #endif
     self = try jsonDecoder.decode(Configuration.self, from: data)
   }
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -293,7 +293,7 @@ public struct Configuration: Codable, Equatable {
   /// Creates a new `Configuration` by decoding it from the UTF-8 representation in the given data.
   public init(data: Data) throws {
     let jsonDecoder = JSONDecoder()
-    #if compiler(>=6)
+    #if canImport(Darwin) || compiler(>=6)
     jsonDecoder.allowsJSON5 = true
     #endif
     self = try jsonDecoder.decode(Configuration.self, from: data)

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -292,7 +292,9 @@ public struct Configuration: Codable, Equatable {
 
   /// Creates a new `Configuration` by decoding it from the UTF-8 representation in the given data.
   public init(data: Data) throws {
-    self = try JSONDecoder().decode(Configuration.self, from: data)
+    let jsonDecoder = JSONDecoder()
+    jsonDecoder.allowsJSON5 = true
+    self = try jsonDecoder.decode(Configuration.self, from: data)
   }
 
   public init(from decoder: Decoder) throws {

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -118,7 +118,7 @@ final class ConfigurationTests: XCTestCase {
   func testConfigurationWithComments() throws {
     #if !canImport(Darwin) && compiler(<6)
     try XCTSkipIf(true, "JSONDecoder does not support JSON5")
-    #endif
+    #else
     let expected = Configuration()
 
     let jsonData = """
@@ -133,5 +133,6 @@ final class ConfigurationTests: XCTestCase {
     jsonDecoder.allowsJSON5 = true
     let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
     XCTAssertEqual(config, expected)
+    #endif
   }
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -23,6 +23,7 @@ final class ConfigurationTests: XCTestCase {
 
     let emptyDictionaryData = "{}\n".data(using: .utf8)!
     let jsonDecoder = JSONDecoder()
+    jsonDecoder.allowsJSON5 = true
     let emptyJSONConfig =
       try! jsonDecoder.decode(Configuration.self, from: emptyDictionaryData)
 
@@ -79,7 +80,9 @@ final class ConfigurationTests: XCTestCase {
         }
         """.data(using: .utf8)!
 
-      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      let jsonDecoder = JSONDecoder()
+      jsonDecoder.allowsJSON5 = true
+      let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
       XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
     }
   }
@@ -99,9 +102,26 @@ final class ConfigurationTests: XCTestCase {
         }
         """.data(using: .utf8)!
 
-      let config = try JSONDecoder().decode(Configuration.self, from: jsonData)
+      let jsonDecoder = JSONDecoder()
+      jsonDecoder.allowsJSON5 = true
+      let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
       XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
     }
   }
 
+  func testConfigurationWithComments() throws {
+    let expected = Configuration()
+
+    let jsonData = """
+      {
+          // Indicates the configuration schema version.
+          "version": 1,
+      }
+      """.data(using: .utf8)!
+
+    let jsonDecoder = JSONDecoder()
+    jsonDecoder.allowsJSON5 = true
+    let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
+    XCTAssertEqual(config, expected)
+  }
 }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -23,7 +23,9 @@ final class ConfigurationTests: XCTestCase {
 
     let emptyDictionaryData = "{}\n".data(using: .utf8)!
     let jsonDecoder = JSONDecoder()
+    #if compiler(>=6)
     jsonDecoder.allowsJSON5 = true
+    #endif
     let emptyJSONConfig =
       try! jsonDecoder.decode(Configuration.self, from: emptyDictionaryData)
 
@@ -81,7 +83,9 @@ final class ConfigurationTests: XCTestCase {
         """.data(using: .utf8)!
 
       let jsonDecoder = JSONDecoder()
+      #if compiler(>=6)
       jsonDecoder.allowsJSON5 = true
+      #endif
       let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
       XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
     }
@@ -103,7 +107,9 @@ final class ConfigurationTests: XCTestCase {
         """.data(using: .utf8)!
 
       let jsonDecoder = JSONDecoder()
+      #if compiler(>=6)
       jsonDecoder.allowsJSON5 = true
+      #endif
       let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
       XCTAssertEqual(config.reflowMultilineStringLiterals, expectedBehavior)
     }
@@ -120,7 +126,9 @@ final class ConfigurationTests: XCTestCase {
       """.data(using: .utf8)!
 
     let jsonDecoder = JSONDecoder()
+    #if compiler(>=6)
     jsonDecoder.allowsJSON5 = true
+    #endif
     let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
     XCTAssertEqual(config, expected)
   }

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -23,7 +23,7 @@ final class ConfigurationTests: XCTestCase {
 
     let emptyDictionaryData = "{}\n".data(using: .utf8)!
     let jsonDecoder = JSONDecoder()
-    #if compiler(>=6)
+    #if canImport(Darwin) || compiler(>=6)
     jsonDecoder.allowsJSON5 = true
     #endif
     let emptyJSONConfig =
@@ -83,7 +83,7 @@ final class ConfigurationTests: XCTestCase {
         """.data(using: .utf8)!
 
       let jsonDecoder = JSONDecoder()
-      #if compiler(>=6)
+      #if canImport(Darwin) || compiler(>=6)
       jsonDecoder.allowsJSON5 = true
       #endif
       let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
@@ -107,7 +107,7 @@ final class ConfigurationTests: XCTestCase {
         """.data(using: .utf8)!
 
       let jsonDecoder = JSONDecoder()
-      #if compiler(>=6)
+      #if canImport(Darwin) || compiler(>=6)
       jsonDecoder.allowsJSON5 = true
       #endif
       let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
@@ -116,6 +116,9 @@ final class ConfigurationTests: XCTestCase {
   }
 
   func testConfigurationWithComments() throws {
+    #if !canImport(Darwin) && compiler(<6)
+    try XCTSkipIf(true, "JSONDecoder does not support JSON5")
+    #endif
     let expected = Configuration()
 
     let jsonData = """
@@ -126,9 +129,8 @@ final class ConfigurationTests: XCTestCase {
       """.data(using: .utf8)!
 
     let jsonDecoder = JSONDecoder()
-    #if compiler(>=6)
+
     jsonDecoder.allowsJSON5 = true
-    #endif
     let config = try jsonDecoder.decode(Configuration.self, from: jsonData)
     XCTAssertEqual(config, expected)
   }


### PR DESCRIPTION
Enable [allowsJSON5](https://developer.apple.com/documentation/foundation/jsondecoder/allowsjson5) on the `JSONDecoder`. With this change, the decoder can now parse JSON5-formatted data.

Resolves #1011.