### PR TITLE
Ensure newline after trailing line comments to prevent formatting issues

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
+++ b/Sources/SwiftFormat/PrettyPrint/PrettyPrint.swift
@@ -146,6 +146,10 @@ public class PrettyPrinter {
   /// enabled (see ``isBreakingSuppressed``).
   private var allowSuppressedDiscretionaryBreaks = false
 
+  /// Overrides break suppression for line or doc comments, or similar cases where a line break is required.
+  /// Reset after handling the break.
+  private var shouldOverrideBreakSuppression = false
+
   /// The computed indentation level, as a number of spaces, based on the state of any unclosed
   /// delimiters and whether or not the current line is a continuation line.
   private var currentIndentation: [Indent] {
@@ -426,7 +430,8 @@ public class PrettyPrinter {
       case .soft(_, let discretionary):
         // A discretionary newline (i.e. from the source) should create a line break even if the
         // rules for breaking are disabled.
-        overrideBreakingSuppressed = discretionary && allowSuppressedDiscretionaryBreaks
+        overrideBreakingSuppressed =
+          shouldOverrideBreakSuppression || (discretionary && allowSuppressedDiscretionaryBreaks)
         mustBreak = true
       case .hard:
         // A hard newline must always create a line break, regardless of the context.
@@ -455,6 +460,7 @@ public class PrettyPrinter {
         outputBuffer.enqueueSpaces(size)
         lastBreak = false
       }
+      shouldOverrideBreakSuppression = false
 
     // Print out the number of spaces according to the size, and adjust spaceRemaining.
     case .space(let size, _):
@@ -472,7 +478,7 @@ public class PrettyPrinter {
 
     case .comment(let comment, let wasEndOfLine):
       lastBreak = false
-
+      shouldOverrideBreakSuppression = comment.kind == .docLine || comment.kind == .line
       if wasEndOfLine {
         if !(canFit(comment.length) || isBreakingSuppressed) {
           diagnose(.moveEndOfLineComment, category: .endOfLineComment)

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -644,4 +644,42 @@ final class AttributeTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
   }
+
+  func testAttributesWithComment() {
+    let input =
+      """
+      @foo // comment
+      @bar
+      import Baz
+
+      """
+    let expected =
+      """
+      @foo  // comment
+      @bar import Baz
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
+
+  func testAttributesWithLineAndBlockComments() {
+    let input =
+      """
+      @foo // comment
+      @bar /* comment */
+      @zoo // comment
+      import Baz
+
+      """
+    let expected =
+      """
+      @foo  // comment
+      @bar /* comment */ @zoo  // comment
+      import Baz
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 45)
+  }
 }


### PR DESCRIPTION
Resolve #1003 

When arranging attributes, they were previously placed on a single line regardless of the presence of line comments.
This change preserves the original behavior of keeping attributes on a single line whenever possible, but inserts a newline when a line comment is present to prevent compilation failures.