### PR TITLE
Fix `unsafe` expressions in `NoAssignmentInExpressions`

### DIFF
--- a/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
+++ b/Sources/SwiftFormat/Rules/NoAssignmentInExpressions.swift
@@ -113,15 +113,15 @@ public final class NoAssignmentInExpressions: SyntaxFormatRule {
 
   /// Returns a value indicating whether the given node is a standalone assignment statement.
   ///
-  /// This function considers try/await expressions and automatically walks up through them as
-  /// needed. This is because `try f().x = y` should still be a standalone assignment for our
+  /// This function considers try/await/unsafe expressions and automatically walks up through them
+  /// as needed. This is because `try f().x = y` should still be a standalone assignment for our
   /// purposes, even though a `TryExpr` will wrap the `InfixOperatorExpr` and thus would not be
   /// considered a standalone assignment if we only checked the infix expression for a
   /// `CodeBlockItem` parent.
   private func isStandaloneAssignmentStatement(_ node: InfixOperatorExprSyntax) -> Bool {
     var node = Syntax(node)
     while let parent = node.parent,
-      parent.is(TryExprSyntax.self) || parent.is(AwaitExprSyntax.self)
+      parent.is(TryExprSyntax.self) || parent.is(AwaitExprSyntax.self) || parent.is(UnsafeExprSyntax.self)
     {
       node = parent
     }

--- a/Tests/SwiftFormatTests/Rules/NoAssignmentInExpressionsTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoAssignmentInExpressionsTests.swift
@@ -187,19 +187,21 @@ final class NoAssignmentInExpressionsTests: LintOrFormatRuleTestCase {
     )
   }
 
-  func testTryAndAwaitAssignmentExpressionsAreUnchanged() {
+  func testTryAndAwaitAndUnsafeAssignmentExpressionsAreUnchanged() {
     assertFormatting(
       NoAssignmentInExpressions.self,
       input: """
         func foo() {
           try a.b = c
           await a.b = c
+          unsafe a.b = c
         }
         """,
       expected: """
         func foo() {
           try a.b = c
           await a.b = c
+          unsafe a.b = c
         }
         """,
       findings: []


### PR DESCRIPTION
fixes #977

refs: https://github.com/swiftlang/swift-format/pull/533