### PR TITLE
Add support for InlineArray type sugar

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1732,6 +1732,14 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: InlineArrayTypeSyntax) -> SyntaxVisitorContinueKind {
+    after(node.leftSquare, tokens: .break(.open, size: 0), .open)
+    before(node.separator, tokens: .space)
+    after(node.separator, tokens: .break)
+    before(node.rightSquare, tokens: .break(.close, size: 0), .close)
+    return .visitChildren
+  }
+
   override func visit(_ node: TupleTypeSyntax) -> SyntaxVisitorContinueKind {
     after(node.leftParen, tokens: .break(.open, size: 0), .open)
     before(node.rightParen, tokens: .break(.close, size: 0), .close)

--- a/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/ArrayDeclTests.swift
@@ -302,4 +302,72 @@ final class ArrayDeclTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 32)
   }
+
+  func testInlineArrayTypeSugar() {
+    let input =
+      """
+      let a: [3 of Int]
+      let a: [[3 of Int]]
+      let a: [3 of [3 of Int]]
+      let a: [n of Int]
+      let fiveIntegers: [5 of _] = .init(repeating: 99)
+      let fourBytes: [_ of Int8] = [1, 2, 3, 4]
+      let fourIntegers: [_ of _] = [1, 2, 3, 4]
+      let fiveDoubles = [5 of _](repeating: 1.23)
+
+      """
+
+    let expected =
+      """
+      let a: [3 of Int]
+      let a: [[3 of Int]]
+      let a: [3 of [3 of Int]]
+      let a: [n of Int]
+      let fiveIntegers: [5 of _] = .init(repeating: 99)
+      let fourBytes: [_ of Int8] = [1, 2, 3, 4]
+      let fourIntegers: [_ of _] = [1, 2, 3, 4]
+      let fiveDoubles = [5 of _](repeating: 1.23)
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 80)
+  }
+
+  func testInlineArrayTypeSugarWhenLineLengthExceeded() {
+    let input =
+      """
+      let a: [3 of VeryLongGenericTypeNameThatCausesWrapping]
+      let a: [3 of [3 of VeryLongGenericTypeNameThatCausesWrapping]]
+      let a = [3 of VeryLongGenericTypeNameThatCausesWrapping](repeating: foo)
+
+      """
+
+    let expected =
+      """
+      let a:
+        [
+          3 of
+            VeryLongGenericTypeNameThatCausesWrapping
+        ]
+      let a:
+        [
+          3 of
+            [
+              3 of
+                VeryLongGenericTypeNameThatCausesWrapping
+            ]
+        ]
+      let a =
+        [
+          3 of
+            VeryLongGenericTypeNameThatCausesWrapping
+        ](
+          repeating:
+            foo
+        )
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 5)
+  }
 }


### PR DESCRIPTION
Resolve #978 

Adds support for the inline array type sugar, now that it has been promoted from an experimental feature.
This change should be merged after https://github.com/swiftlang/swift-syntax/pull/3125 has been merged.