### PR TITLE
Update links for repositories moved from apple to swiftlang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 find_package(cmark-gfm CONFIG)
 if(NOT cmark-gfm_FOUND)
   FetchContent_Declare(cmark-gfm
-    GIT_REPOSITORY https://github.com/apple/swift-cmark
+    GIT_REPOSITORY https://github.com/swiftlang/swift-cmark
     GIT_TAG gfm)
   list(APPEND _SF_VENDOR_DEPENDENCIES cmark-gfm)
 endif()
@@ -60,7 +60,7 @@ if(NOT SwiftMarkdown_FOUND)
   # TODO(compnerd) we need a latest version for now as we need the CMake support
   # which is untagged.
   FetchContent_Declare(Markdown
-    GIT_REPOSITORY https://github.com/apple/swift-markdown
+    GIT_REPOSITORY https://github.com/swiftlang/swift-markdown
     GIT_TAG main)
   list(APPEND _SF_VENDOR_DEPENDENCIES Markdown)
 endif()

--- a/Package.swift
+++ b/Package.swift
@@ -197,7 +197,7 @@ var dependencies: [Package.Dependency] {
   } else {
     return [
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
-      .package(url: "https://github.com/apple/swift-markdown.git", from: "0.2.0"),
+      .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.2.0"),
       .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     ]
   }


### PR DESCRIPTION
This causes the following warning when another project depends on it alongside a link to the `swiftlang`.

<img width="687" height="83" src="https://github.com/user-attachments/assets/6d29b1ec-ae77-4893-9ebc-3841c74bc2c9" />
