### PR TITLE
Skip self-hosted CI jobs on forks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
       linux_pre_build_command: INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
       linux_build_command: './.github/scripts/cmake-smoke-test.sh -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++` -DCMAKE_Swift_COMPILER=`which swiftc`'
       linux_swift_versions: '["nightly-main"]'
-      enable_macos_checks: true
+      enable_macos_checks: ${{ github.repository == 'swiftlang/swift-format' }}
       macos_xcode_versions: '["swift_6.3"]'
       macos_pre_build_command: INSTALL_CMAKE=1 ./.github/scripts/prebuild.sh
       macos_build_command: 'export PATH=$PATH:$RUNNER_TOOL_CACHE && ./.github/scripts/cmake-smoke-test.sh -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++` -DCMAKE_Swift_COMPILER=`which swiftc`'


### PR DESCRIPTION
PR #1241 has added the `cmake-smoke-test` job, and it requires a self-hosted runner for macOS. However, self-hosted runners are not available for forked repositories. This causes CI to hang and fail after a long period of time on forked repositories. This is frustrating for contributors.

- https://github.com/swiftlang/github-workflows/issues/305

To solve that, I've changed `enable_macos_checks` of `cmake-smoke-test` from `true` to `${{ github.repository == 'swiftlang/swift-format' }}`. If the workflow is running in the upstream repository, macOS checks remain enabled. In forked repositories, they are skipped.

Similar PR: https://github.com/swiftlang/swiftly/pull/471