### PR TITLE
Re-indent multi-line interpolations with their string literal

### DIFF
--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1340,8 +1340,34 @@ private final class TokenStreamCreator: SyntaxVisitor {
     // TODO: For now, just use the raw text of the node and don't try to format it deeper. In the
     // future, we should find a way to format the expression but without wrapping so that at least
     // internal whitespace is fixed.
-    appendToken(.syntax(node.description))
-    // Visiting children is not needed here.
+    let text = node.description
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+
+    // An interpolation that spans multiple lines still has the indentation it had in the original
+    // source. The rest of the multiline string is re-indented by the pretty printer, so emitting
+    // the raw text would leave these lines behind, and a line less indented than the closing
+    // delimiter doesn't compile. Emit each line separately instead, dropping the literal's original
+    // indentation so the printer can apply the new one.
+    guard lines.count > 1,
+      let stringLiteral = node.parent?.as(StringLiteralSegmentListSyntax.self)?.parent?
+        .as(StringLiteralExprSyntax.self),
+      stringLiteral.openingQuote.tokenKind == .multilineStringQuote
+    else {
+      appendToken(.syntax(text))
+      return .skipChildren
+    }
+
+    let originalIndentation = stringLiteral.closingQuote.leadingTrivia.reversed()
+      .prefix { $0.isSpaceOrTab }
+      .reduce(0) { $0 + $1.sourceLength.utf8Length }
+    let breakKind = pendingMultilineStringBreakKinds[stringLiteral, default: .same]
+
+    appendToken(.syntax(String(lines[0])))
+    for line in lines.dropFirst() {
+      let strippableWhitespace = line.prefix { $0 == " " || $0 == "\t" }.count
+      appendToken(.break(breakKind, newlines: .hard(count: 1)))
+      appendToken(.syntax(String(line.dropFirst(min(originalIndentation, strippableWhitespace)))))
+    }
     return .skipChildren
   }
 

--- a/Tests/SwiftFormatTests/PrettyPrint/StringTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/StringTests.swift
@@ -776,4 +776,43 @@ final class StringTests: PrettyPrintTestCase {
 
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 30)
   }
+
+  func testMultilineInterpolationIsReindentedWithTheLiteral() {
+    let input =
+      #"""
+      func test() {
+        foo(
+          """
+      \(bar(
+          baz))
+      """)
+        foo(
+          """
+      \(items.map {
+        $0
+      }.joined())
+      """)
+      }
+      """#
+
+    let expected =
+      #"""
+      func test() {
+        foo(
+          """
+          \(bar(
+              baz))
+          """)
+        foo(
+          """
+          \(items.map {
+            $0
+          }.joined())
+          """)
+      }
+
+      """#
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 100)
+  }
 }


### PR DESCRIPTION
Fixes #783. Fixes #1226. Same root cause, so one diff covers both.

**What's wrong today.** A `\(...)` interpolation that spans lines keeps the indentation it had in the source, while the rest of the multiline string is re-indented by the pretty printer. The continuation lines get left behind, and once they sit further left than the closing delimiter the output stops compiling.

#783, with `indentation: .spaces(4)`:

```swift
f(
  """
  \(x ? "" :
  y)
  """)
```

formats to

```swift
f(
    """
    \(x ? "" :
  y)
    """)
```

`error: insufficient indentation of line in multi-line string literal`. swift-format can't parse its own output, so this also breaks idempotency. #1226 is the same thing with a wrapped call inside the interpolation.

**Why.** `visit(ExpressionSegmentSyntax)` emits `node.description` as a single `.syntax` token. Newlines inside that token go straight to the output buffer, so the printer never gets a chance to indent those lines, unlike the string's own segments which are separated by hard breaks and picked up by the current indentation.

**What this does.** Split the interpolation on newlines and emit each line as its own token with the same hard break kind the surrounding string uses, dropping the literal's original indentation (taken from the closing delimiter's leading trivia) so the printer applies the new one. Indentation relative to the literal is kept, so a wrapped argument list or closure body inside the interpolation keeps its shape:

```swift
foo(
  """
  \(items.map {
    $0
  }.joined())
  """)
```

The `TODO` above this function still stands. This doesn't format the interpolated expression, it only stops the existing text from being emitted at the wrong indentation.

**Verification.** `swift test` doesn't run on this machine (Command Line Tools only, so no `XCTest` for `_SwiftFormatTestSupport`), so I leaned on differential testing and the suite will run here in CI.

- Built `swift-format` before and after and formatted 1408 real files with each project's own config: swift-syntax `Sources`, `Tests`, `Examples` and `CodeGeneration` (which is almost entirely multiline strings full of `\(raw:)` interpolations, so it's the case that would break first), sourcekit-lsp `Sources` and `Tests`, and this repo's `Sources` and `Tests`. Zero output differences, which is what the compatibility job checks.
- Pulled all 91 multiline literals containing an interpolation or a nested `"""` out of `Tests/SwiftFormatTests` and formatted them with both binaries across line lengths 20 to 120, both `reflowMultilineStringLiterals` settings, tab indentation, 4-space indentation and `respectsExistingLineBreaks: false`. Zero differences.
- Checked raw strings (`#"""` with `\#(...)`), a multiline string nested inside an interpolation, a blank line inside an interpolation (no trailing whitespace introduced), and CRLF input (byte identical to before).
- Both issues' outputs now pass `swiftc -parse` and are idempotent; the old outputs fail to parse.

I couldn't reproduce #864 from the snippet in that issue, the snippet doesn't parse as written, so I'm not claiming this fixes it even though it looks related.

Same note as my other PR: CI here will need a maintainer to approve the run.

---

sorry in advance if something in here is off. i reasoned through the indentation logic myself and used claude code to sanity check the approach, so any mistakes are mine and i'd rather hear about them than not. college freshman, just trying to be genuinely useful :)