### PR TITLE
Preserve trailing comments on case labels in NoCasesWithOnlyFallthrough

### DIFF
--- a/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
@@ -145,9 +145,10 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
     {
       return false
     }
-    // Check for any comments on or trailing the case label (e.g. after the colon).
+    // Check for any comments on or trailing the case label (e.g. after the colon or between patterns).
     if switchCase.label.tokens(viewMode: .sourceAccurate).contains(where: { token in
-      token.trailingTrivia.contains(where: { $0.isComment })
+      token.trailingTrivia.contains(where: { $0.isComment }) ||
+      token.leadingTrivia.contains(where: { $0.isComment })
     }) {
       return false
     }

--- a/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
+++ b/Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift
@@ -145,6 +145,17 @@ public final class NoCasesWithOnlyFallthrough: SyntaxFormatRule {
     {
       return false
     }
+    // Check for any comments on or trailing the case label (e.g. after the colon).
+    if switchCase.label.tokens(viewMode: .sourceAccurate).contains(where: { token in
+      token.trailingTrivia.contains(where: { $0.isComment })
+    }) {
+      return false
+    }
+    if switchCase.label.allFollowingTrivia
+      .prefix(while: { !$0.isNewline }).contains(where: { $0.isComment })
+    {
+      return false
+    }
     if onlyStatement.allPrecedingTrivia
       .drop(while: { !$0.isNewline }).contains(where: { $0.isComment })
     {

--- a/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
+++ b/Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift
@@ -367,4 +367,44 @@ final class NoCasesWithOnlyFallthroughTests: LintOrFormatRuleTestCase {
       ]
     )
   }
+
+  func testFallthroughCasesWithTrailingCaseLabelCommentsAreNotCombined() {
+    assertFormatting(
+      NoCasesWithOnlyFallthrough.self,
+      input: """
+        func f(x: Int) {
+          switch x {
+          case 1:  // trail on 1
+            fallthrough
+          case 2:
+            print("hi")
+          case 3:  /* block trail on 3 */
+            fallthrough
+          case 4:
+            print("hello")
+          default:
+            break
+          }
+        }
+        """,
+      expected: """
+        func f(x: Int) {
+          switch x {
+          case 1:  // trail on 1
+            fallthrough
+          case 2:
+            print("hi")
+          case 3:  /* block trail on 3 */
+            fallthrough
+          case 4:
+            print("hello")
+          default:
+            break
+          }
+        }
+        """,
+      findings: []
+    )
+  }
 }
+


### PR DESCRIPTION
### Motivation

Fixes #1274.

When `NoCasesWithOnlyFallthrough` merged a fallthrough-only `case` into the following case, comments trailing the `case` label (e.g. on the same line as the colon: `case 1:  // comment`) were discarded from the output AST because `isMergeableFallthroughOnly(_:)` only checked for comments adjacent to the statement or on the fallthrough token itself.

### Modifications

- In `Sources/SwiftFormat/Rules/NoCasesWithOnlyFallthrough.swift`, added checks for trailing comments on tokens within `switchCase.label` and trailing comments on the label itself before marking the case as mergeable.
- In `Tests/SwiftFormatTests/Rules/NoCasesWithOnlyFallthroughTests.swift`, added `testFallthroughCasesWithTrailingCaseLabelCommentsAreNotCombined` to ensure line and block comments on case labels prevent unwanted collapsing and preserve comments intact.

### Result

Comments trailing `case` labels in fallthrough-only cases are no longer silently deleted during formatting.