### PR TITLE
Bump the Swift version to 6.3.4

### DIFF
--- a/Sources/swift-format/PrintVersion.swift
+++ b/Sources/swift-format/PrintVersion.swift
@@ -12,5 +12,5 @@
 
 func printVersionInformation() {
   // TODO: Automate updates to this somehow.
-  print("6.3.3")
+  print("6.3.4")
 }


### PR DESCRIPTION
- **Explanation**: Update the Swift version to 6.3.4
- **Scope**: Change the version of swift-format on release/6.3 branch
- **Issues**: Version expected for release/6.3 is 6.3.4, currently reporting 6.3.3
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: CI
- **Reviewers**: