### PR TITLE
Bump the Swift version to 6.4.1

### DIFF
--- a/Sources/swift-format/PrintVersion.swift
+++ b/Sources/swift-format/PrintVersion.swift
@@ -12,5 +12,5 @@
 
 func printVersionInformation() {
   // TODO: Automate updates to this somehow.
-  print("main")
+  print("6.4.1")
 }


### PR DESCRIPTION
- **Explanation**: Update the Swift version to 6.4.1
- **Scope**: Change the version of swift-format on release/6.4.1 branch
- **Issues**: Version expected for release/6.4.1 is 6.4.1, currently reporting "main"
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: CI
- **Reviewers**:

Note: swiftlang/swift-format#1276 (`updateversion/6.4.1`) already makes this same change via the repo's automated version-bump workflow. Opening this in parallel per explicit request; feel free to close whichever is redundant.