### PR TITLE
Match **/ ignore patterns at component boundaries

### DIFF
--- a/Sources/SwiftFormat/Utilities/GitIgnorePattern.swift
+++ b/Sources/SwiftFormat/Utilities/GitIgnorePattern.swift
@@ -158,7 +158,7 @@ public struct GitIgnorePattern {
       // Pattern: **/suffix (matches suffix at any depth)
       if prefix.isEmpty {
         let cleanSuffix = suffix.hasPrefix("/") ? String(suffix.dropFirst()) : suffix
-        return path.hasSuffix(cleanSuffix) || simpleMatch(path, pattern: cleanSuffix)
+        return matchesAtAnyDepth(path, pattern: cleanSuffix)
       }
 
       // Pattern: prefix/** (matches everything under prefix)
@@ -197,6 +197,18 @@ public struct GitIgnorePattern {
       }
     }
 
+    return false
+  }
+
+  /// Tests the pattern against every suffix of the path that starts at a component boundary,
+  /// which is what a leading `**/` means.
+  private func matchesAtAnyDepth(_ path: String, pattern: String) -> Bool {
+    let components = path.components(separatedBy: "/")
+    for index in components.indices {
+      if simpleMatch(components[index...].joined(separator: "/"), pattern: pattern) {
+        return true
+      }
+    }
     return false
   }
 

--- a/Tests/SwiftFormatTests/Utilities/GitIgnorePatternTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/GitIgnorePatternTests.swift
@@ -95,6 +95,31 @@ struct GitIgnorePatternTests {
     #expect(pattern.matches("test.java", isDirectory: false) == false)
   }
 
+  @Test func doubleAsteriskPatternWithWildcardSuffix() throws {
+    let pattern = try GitIgnorePattern("**/*.generated.swift")
+
+    #expect(pattern.matches("top.generated.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/x.generated.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/deep/deep.generated.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/main.swift", isDirectory: false) == false)
+  }
+
+  @Test func doubleAsteriskPatternRespectsComponentBoundaries() throws {
+    let pattern = try GitIgnorePattern("**/Generated")
+
+    #expect(pattern.matches("Generated", isDirectory: true) == true)
+    #expect(pattern.matches("src/Generated", isDirectory: true) == true)
+    #expect(pattern.matches("src/MyGenerated", isDirectory: true) == false)
+    #expect(pattern.matches("MyGenerated", isDirectory: true) == false)
+  }
+
+  @Test func doubleAsteriskDirectoryOnlyPatternRespectsComponentBoundaries() throws {
+    let pattern = try GitIgnorePattern("**/Generated/")
+
+    #expect(pattern.matches("src/Generated/G.swift", isDirectory: false) == true)
+    #expect(pattern.matches("src/MyGenerated/M.swift", isDirectory: false) == false)
+  }
+
   @Test func doubleAsteriskDirectoryPattern() throws {
     let pattern = try GitIgnorePattern("src/**/build")
 


### PR DESCRIPTION
A `.swift-format-ignore` pattern beginning with `**/` was matched with `path.hasSuffix(rest) || simpleMatch(path, rest)`. The suffix test ignores component boundaries, so `**/Generated` also ignored `src/MyGenerated`, and `simpleMatch`'s `*` stops at `/`, so `**/*.generated.swift` matched only at depth zero.

The rest of the pattern is now tried against every suffix of the path that starts at a component boundary. Three tests cover the wildcard suffix, the directory name, and the directory-only form; they fail on main.
