### PR TITLE
Reject negative numeric values in a configuration file

### DIFF
--- a/Documentation/Configuration.md
+++ b/Documentation/Configuration.md
@@ -8,6 +8,10 @@ used as a command line tool or as an API.
 A `swift-format` configuration file is a JSON file with the following
 top-level keys and values:
 
+Every numeric setting below is a count, a length, or a width, so none of them
+accepts a negative value. A configuration carrying one is rejected with an error
+naming the offending key rather than applied.
+
 ### `version`  
 **type:** number  
 

--- a/Sources/SwiftFormat/API/Configuration.swift
+++ b/Sources/SwiftFormat/API/Configuration.swift
@@ -348,18 +348,27 @@ public struct Configuration: Codable, Equatable {
     // default-initialized instance.
     let defaults = Configuration()
 
-    self.maximumBlankLines =
-      try container.decodeIfPresent(Int.self, forKey: .maximumBlankLines)
-      ?? defaults.maximumBlankLines
-    self.lineLength =
-      try container.decodeIfPresent(Int.self, forKey: .lineLength)
-      ?? defaults.lineLength
-    self.spacesBeforeEndOfLineComments =
-      try container.decodeIfPresent(Int.self, forKey: .spacesBeforeEndOfLineComments)
-      ?? defaults.spacesBeforeEndOfLineComments
-    self.tabWidth =
-      try container.decodeIfPresent(Int.self, forKey: .tabWidth)
-      ?? defaults.tabWidth
+    func decodeNonNegative(_ key: CodingKeys, default defaultValue: Int) throws -> Int {
+      guard let value = try container.decodeIfPresent(Int.self, forKey: key) else {
+        return defaultValue
+      }
+      guard value >= 0 else {
+        throw DecodingError.dataCorruptedError(
+          forKey: key,
+          in: container,
+          debugDescription: "expected a non-negative value, but found \(value)"
+        )
+      }
+      return value
+    }
+
+    self.maximumBlankLines = try decodeNonNegative(.maximumBlankLines, default: defaults.maximumBlankLines)
+    self.lineLength = try decodeNonNegative(.lineLength, default: defaults.lineLength)
+    self.spacesBeforeEndOfLineComments = try decodeNonNegative(
+      .spacesBeforeEndOfLineComments,
+      default: defaults.spacesBeforeEndOfLineComments
+    )
+    self.tabWidth = try decodeNonNegative(.tabWidth, default: defaults.tabWidth)
     self.indentation =
       try container.decodeIfPresent(Indent.self, forKey: .indentation)
       ?? defaults.indentation

--- a/Sources/SwiftFormat/API/Indent.swift
+++ b/Sources/SwiftFormat/API/Indent.swift
@@ -40,12 +40,24 @@ public enum Indent: Hashable, Codable {
         )
       )
     }
+    func validated(_ count: Int, _ key: CodingKeys) throws -> Int {
+      guard count >= 0 else {
+        throw DecodingError.dataCorrupted(
+          DecodingError.Context(
+            codingPath: decoder.codingPath + [key],
+            debugDescription: "expected a non-negative value, but found \(count)"
+          )
+        )
+      }
+      return count
+    }
+
     if let spacesCount = spacesCount {
-      self = .spaces(spacesCount)
+      self = .spaces(try validated(spacesCount, .spaces))
       return
     }
     if let tabsCount = tabsCount {
-      self = .tabs(tabsCount)
+      self = .tabs(try validated(tabsCount, .tabs))
       return
     }
 

--- a/Tests/SwiftFormatTests/API/ConfigurationTests.swift
+++ b/Tests/SwiftFormatTests/API/ConfigurationTests.swift
@@ -135,4 +135,41 @@ final class ConfigurationTests: XCTestCase {
     XCTAssertEqual(config, expected)
     #endif
   }
+
+  func testNegativeNumericValuesAreRejected() throws {
+    // Every numeric setting is a count, a length, or a width. Nothing downstream is prepared for a
+    // negative one: a negative lineLength trips an assertion in the pretty printer and a negative
+    // indentation count reaches String(repeating:count:), which traps.
+    let cases: [(json: String, key: String)] = [
+      (#"{"version":1,"maximumBlankLines":-1}"#, "maximumBlankLines"),
+      (#"{"version":1,"lineLength":-5}"#, "lineLength"),
+      (#"{"version":1,"spacesBeforeEndOfLineComments":-1}"#, "spacesBeforeEndOfLineComments"),
+      (#"{"version":1,"tabWidth":-1}"#, "tabWidth"),
+      (#"{"version":1,"indentation":{"spaces":-4}}"#, "spaces"),
+      (#"{"version":1,"indentation":{"tabs":-2}}"#, "tabs"),
+    ]
+    for (json, key) in cases {
+      XCTAssertThrowsError(
+        try Configuration(data: json.data(using: .utf8)!),
+        "expected \(key) to be rejected"
+      ) { error in
+        guard case DecodingError.dataCorrupted(let context) = error else {
+          XCTFail("expected a dataCorrupted error for \(key), got \(error)")
+          return
+        }
+        XCTAssertEqual(context.codingPath.last?.stringValue, key)
+      }
+    }
+  }
+
+  func testNonNegativeNumericValuesAreAccepted() throws {
+    // Zero is meaningful for these settings and must keep decoding.
+    let config = try Configuration(
+      data: #"{"version":1,"maximumBlankLines":0,"tabWidth":0,"indentation":{"spaces":0}}"#
+        .data(using: .utf8)!
+    )
+    XCTAssertEqual(config.maximumBlankLines, 0)
+    XCTAssertEqual(config.tabWidth, 0)
+    XCTAssertEqual(config.indentation, .spaces(0))
+  }
 }


### PR DESCRIPTION
A hand-written `.swift-format` carrying a negative `lineLength`, `tabWidth`, `maximumBlankLines`, `spacesBeforeEndOfLineComments` or indentation count aborted the process: a negative line length trips an assertion in the pretty printer and a negative indentation count reaches `String(repeating:count:)`, which traps.

Decoding now rejects a negative value with a `DecodingError` naming the key, so the user sees a diagnostic. Zero still decodes. Two tests cover the rejection for every key and the zero case; the rejection test fails on main.
