### PR TITLE
Keep the file mode when formatting in place

### DIFF
--- a/Sources/SwiftFormat/CMakeLists.txt
+++ b/Sources/SwiftFormat/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(SwiftFormat
   Rules/UseTripleSlashForDocumentationComments.swift
   Rules/UseWhereClausesInForLoops.swift
   Rules/ValidateDocumentationComments.swift
+  Utilities/Data+writeAtomicallyPreservingPermissions.swift
   Utilities/FileIterator.swift
   Utilities/GitIgnorePattern.swift
   Utilities/IgnoreManager.swift

--- a/Sources/SwiftFormat/Utilities/Data+writeAtomicallyPreservingPermissions.swift
+++ b/Sources/SwiftFormat/Utilities/Data+writeAtomicallyPreservingPermissions.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension Data {
+  /// Writes the data to `url` atomically, restoring the permissions the file had before the write.
+  ///
+  /// An atomic write replaces the file rather than rewriting it, so the result is a new file created at the process
+  /// umask and any mode the original carried is lost.
+  @_spi(Internal) public func writeAtomicallyPreservingPermissions(to url: URL) throws {
+    let permissions = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.posixPermissions]
+    try write(to: url, options: .atomic)
+    if let permissions {
+      try? FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: url.path)
+    }
+  }
+}

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import SwiftDiagnostics
-import SwiftFormat
+@_spi(Internal) import SwiftFormat
 import SwiftSyntax
 
 /// The frontend for formatting operations.
@@ -63,16 +63,7 @@ class FormatFrontend: Frontend {
 
         if buffer != source {
           let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
-          // The atomic write replaces the file, so its mode has to be carried over.
-          let originalPermissions =
-            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.posixPermissions]
-          try bufferData.write(to: url, options: .atomic)
-          if let originalPermissions {
-            try? FileManager.default.setAttributes(
-              [.posixPermissions: originalPermissions],
-              ofItemAtPath: url.path
-            )
-          }
+          try bufferData.writeAtomicallyPreservingPermissions(to: url)
         }
       } else {
         try formatter.format(

--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -63,7 +63,16 @@ class FormatFrontend: Frontend {
 
         if buffer != source {
           let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
+          // The atomic write replaces the file, so its mode has to be carried over.
+          let originalPermissions =
+            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.posixPermissions]
           try bufferData.write(to: url, options: .atomic)
+          if let originalPermissions {
+            try? FileManager.default.setAttributes(
+              [.posixPermissions: originalPermissions],
+              ofItemAtPath: url.path
+            )
+          }
         }
       } else {
         try formatter.format(

--- a/Tests/SwiftFormatTests/Utilities/DataWriteAtomicallyPreservingPermissionsTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/DataWriteAtomicallyPreservingPermissionsTests.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !os(Windows)
+
+import Foundation
+@_spi(Internal) import SwiftFormat
+import Testing
+
+@Suite
+struct DataWriteAtomicallyPreservingPermissionsTests {
+
+  @Test(arguments: [0o600, 0o444, 0o755])
+  func keepsThePermissionsTheFileHad(mode: Int) throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SwiftFormatPermissionsTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let file = directory.appendingPathComponent("Test.swift")
+    try "class Test {}".write(to: file, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: file.path)
+
+    try Data("class Formatted {}".utf8).writeAtomicallyPreservingPermissions(to: file)
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+    #expect(attributes[.posixPermissions] as? Int == mode)
+    #expect(try String(contentsOf: file, encoding: .utf8) == "class Formatted {}")
+  }
+
+  @Test func writesAFileThatDidNotExist() throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("SwiftFormatPermissionsTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let file = directory.appendingPathComponent("New.swift")
+    try Data("class New {}".utf8).writeAtomicallyPreservingPermissions(to: file)
+
+    #expect(try String(contentsOf: file, encoding: .utf8) == "class New {}")
+  }
+}
+
+#endif


### PR DESCRIPTION
`swift-format format --in-place` writes with `Data.write(to:options:.atomic)`, which replaces the file rather than rewriting it, so the result is a new file created at the process umask. A source file the user had at 0600 came back 0644, and a 0444 one lost its read-only bit.

The mode is read before the write and restored after it.

On main, formatting a 0600, 0444 or 0755 file in place leaves it at 0644; with this change each keeps its mode.
